### PR TITLE
feat(cli): walking skeleton with version subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Go
+/bin/
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+*.test
+*.out
+*.prof
+coverage.txt
+coverage.html
+
+# macOS
+.DS_Store
+._*
+
+# Build artifacts
+/srs
+/dist/
+
+# Editor
+*.swp
+*.swo
+*~
+.idea/
+.vscode/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Joaquín Corredor
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# srs
+
+A spaced-repetition TUI built around the FSRS algorithm and Markdown card files. See [#1](https://github.com/jvcorredor/srs-tui/issues/1) for the full roadmap.
+
+## Install
+
+```sh
+go install github.com/jvcorredor/srs-tui/cmd/srs@latest
+```
+
+## Keybindings
+
+| Key | Action |
+|-----|--------|
+| _TBD_ | _TBD_ |

--- a/cmd/srs/main.go
+++ b/cmd/srs/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"os"
+
+	"github.com/jvcorredor/srs-tui/internal/cli"
+)
+
+func main() {
+	os.Exit(cli.Execute())
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/jvcorredor/srs-tui
+
+go 1.23
+
+require github.com/spf13/cobra v1.10.2
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+func SetVersion(v, c, d string) {
+	version = v
+	commit = c
+	date = d
+}
+
+func SetOutput(w io.Writer) {
+	rootOut = w
+}
+
+var rootOut io.Writer
+
+func NewRootCmd() *cobra.Command {
+	root := &cobra.Command{
+		Use:   "srs",
+		Short: "Spaced repetition in the terminal",
+	}
+	root.SetOut(rootOut)
+
+	root.AddCommand(newVersionCmd())
+	return root
+}
+
+func newVersionCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print version info",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Fprintf(cmd.OutOrStdout(), "srs %s\ncommit: %s\ndate:   %s\n", version, commit, date)
+			return nil
+		},
+	}
+}
+
+func Execute() int {
+	root := NewRootCmd()
+	if err := root.Execute(); err != nil {
+		return 1
+	}
+	return 0
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,43 @@
+package cli_test
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/jvcorredor/srs-tui/internal/cli"
+)
+
+func TestVersionCommandPrintsVersion(t *testing.T) {
+	buf := new(bytes.Buffer)
+	cli.SetOutput(buf)
+	cli.SetVersion("0.0.0-dev", "abc1234", "2026-01-01")
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"version"})
+	cmd.SetOut(buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("version command failed: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "0.0.0-dev") {
+		t.Errorf("version output missing version string: got %q", out)
+	}
+	if !strings.Contains(out, "abc1234") {
+		t.Errorf("version output missing commit: got %q", out)
+	}
+	if !strings.Contains(out, "2026-01-01") {
+		t.Errorf("version output missing date: got %q", out)
+	}
+}
+
+func TestExecuteReturnsZero(t *testing.T) {
+	cli.SetOutput(io.Discard)
+	code := cli.Execute()
+	if code != 0 {
+		t.Errorf("Execute() = %d, want 0", code)
+	}
+}


### PR DESCRIPTION
## Summary

- Go module (`github.com/jvcorredor/srs-tui`, Go 1.23) with cobra CLI wiring
- `srs version` prints version, commit, and date via ldflags-ready build metadata
- `cmd/srs/main.go` entry point defers to `internal/cli.Execute()`
- Two behavior tests: version output contains metadata, root command exits 0
- Repo hygiene: MIT LICENSE, stub README, .gitignore

Closes: #2