### PR TITLE
feat(init): add srs init subcommand with config scaffolding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.6.0 // indirect
 	github.com/alecthomas/chroma/v2 v2.20.0 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
 github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
 github.com/alecthomas/chroma/v2 v2.20.0 h1:sfIHpxPyR07/Oylvmcai3X/exDlE8+FA820NTz+9sGw=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"io"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/jvcorredor/srs-tui/internal/card"
+	"github.com/jvcorredor/srs-tui/internal/config"
 	"github.com/jvcorredor/srs-tui/internal/deck"
 	"github.com/jvcorredor/srs-tui/internal/fsrs"
 	"github.com/jvcorredor/srs-tui/internal/paths"
@@ -111,6 +113,7 @@ func NewRootCmd() *cobra.Command {
 
 	root.AddCommand(newVersionCmd())
 	root.AddCommand(newReviewCmd())
+	root.AddCommand(newInitCmd())
 	return root
 }
 
@@ -137,6 +140,51 @@ func newVersionCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+func newInitCmd() *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Scaffold default config and decks directory",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return RunInit(
+				paths.ConfigHome(),
+				paths.DataHome(),
+				force,
+				cmd.OutOrStdout(),
+				cmd.OutOrStderr(),
+			)
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "overwrite existing config.toml")
+	return cmd
+}
+
+func RunInit(configDir, dataDir string, force bool, stdout, stderr io.Writer) error {
+	srsConfigDir := filepath.Join(configDir, "srs")
+	configPath := filepath.Join(srsConfigDir, "config.toml")
+
+	if _, err := os.Stat(configPath); err == nil && !force {
+		fmt.Fprintf(stderr, "config.toml already exists; use --force to overwrite\n")
+		return fmt.Errorf("config.toml already exists")
+	}
+
+	if err := os.MkdirAll(srsConfigDir, 0o755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+
+	if err := os.WriteFile(configPath, []byte(config.DefaultConfigContent()), 0o644); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+
+	decksRoot := filepath.Join(dataDir, "srs", "decks")
+	if err := os.MkdirAll(decksRoot, 0o755); err != nil {
+		return fmt.Errorf("create decks root: %w", err)
+	}
+
+	fmt.Fprintf(stdout, "Created %s\nCreated %s\n", configPath, decksRoot)
+	return nil
 }
 
 func Execute() int {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -174,3 +174,174 @@ func TestMakeRateFuncAssignsID(t *testing.T) {
 		t.Error("card should have ID assigned after first rating")
 	}
 }
+
+func TestRunInitWritesDefaultConfig(t *testing.T) {
+	configDir := t.TempDir()
+	dataDir := t.TempDir()
+
+	var stdout, stderr bytes.Buffer
+	err := cli.RunInit(configDir, dataDir, false, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("RunInit() error: %v", err)
+	}
+
+	configPath := filepath.Join(configDir, "srs", "config.toml")
+	b, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("reading config.toml: %v", err)
+	}
+
+	content := string(b)
+	if !strings.Contains(content, "decks_root") {
+		t.Error("config template missing decks_root")
+	}
+	if !strings.Contains(content, "new_per_day") {
+		t.Error("config template missing new_per_day")
+	}
+	if !strings.Contains(content, "command") {
+		t.Error("config template missing editor command")
+	}
+	if !strings.Contains(content, "style") {
+		t.Error("config template missing render style")
+	}
+}
+
+func TestRunInitCreatesDecksRoot(t *testing.T) {
+	configDir := t.TempDir()
+	dataDir := t.TempDir()
+
+	var stdout, stderr bytes.Buffer
+	err := cli.RunInit(configDir, dataDir, false, &stdout, &stderr)
+	if err != nil {
+		t.Fatalf("RunInit() error: %v", err)
+	}
+
+	decksRoot := filepath.Join(dataDir, "srs", "decks")
+	info, err := os.Stat(decksRoot)
+	if err != nil {
+		t.Fatalf("stat decks_root: %v", err)
+	}
+	if !info.IsDir() {
+		t.Errorf("decks_root %q is not a directory", decksRoot)
+	}
+}
+
+func TestRunInitRefusesOverwriteWithoutForce(t *testing.T) {
+	configDir := t.TempDir()
+	dataDir := t.TempDir()
+
+	var stdout, stderr bytes.Buffer
+	if err := cli.RunInit(configDir, dataDir, false, &stdout, &stderr); err != nil {
+		t.Fatalf("first RunInit() error: %v", err)
+	}
+
+	var stdout2, stderr2 bytes.Buffer
+	err := cli.RunInit(configDir, dataDir, false, &stdout2, &stderr2)
+	if err == nil {
+		t.Fatal("expected error when config already exists without --force")
+	}
+
+	if !strings.Contains(stderr2.String(), "already exists") {
+		t.Errorf("stderr = %q, want mention of already exists", stderr2.String())
+	}
+}
+
+func TestRunInitOverwritesWithForce(t *testing.T) {
+	configDir := t.TempDir()
+	dataDir := t.TempDir()
+
+	var stdout, stderr bytes.Buffer
+	if err := cli.RunInit(configDir, dataDir, false, &stdout, &stderr); err != nil {
+		t.Fatalf("first RunInit() error: %v", err)
+	}
+
+	configPath := filepath.Join(configDir, "srs", "config.toml")
+	original, _ := os.ReadFile(configPath)
+
+	os.WriteFile(configPath, append(original, []byte("# extra\n")...), 0o644)
+
+	var stdout2, stderr2 bytes.Buffer
+	if err := cli.RunInit(configDir, dataDir, true, &stdout2, &stderr2); err != nil {
+		t.Fatalf("RunInit with force: %v", err)
+	}
+
+	after, _ := os.ReadFile(configPath)
+	if strings.Contains(string(after), "# extra") {
+		t.Error("force should overwrite with default template, but old content remains")
+	}
+}
+
+func TestRunInitPrintsSuccessSummary(t *testing.T) {
+	configDir := t.TempDir()
+	dataDir := t.TempDir()
+
+	var stdout, stderr bytes.Buffer
+	if err := cli.RunInit(configDir, dataDir, false, &stdout, &stderr); err != nil {
+		t.Fatalf("RunInit() error: %v", err)
+	}
+
+	out := stdout.String()
+	configPath := filepath.Join(configDir, "srs", "config.toml")
+	if !strings.Contains(out, configPath) {
+		t.Errorf("stdout missing config path %q: got %q", configPath, out)
+	}
+	decksRoot := filepath.Join(dataDir, "srs", "decks")
+	if !strings.Contains(out, decksRoot) {
+		t.Errorf("stdout missing decks_root %q: got %q", decksRoot, out)
+	}
+	if stderr.Len() > 0 {
+		t.Errorf("unexpected stderr output: %q", stderr.String())
+	}
+}
+
+func TestRunInitIdempotentWithForce(t *testing.T) {
+	configDir := t.TempDir()
+	dataDir := t.TempDir()
+
+	var stdout1, stderr1 bytes.Buffer
+	if err := cli.RunInit(configDir, dataDir, false, &stdout1, &stderr1); err != nil {
+		t.Fatalf("first RunInit(): %v", err)
+	}
+
+	firstConfig, _ := os.ReadFile(filepath.Join(configDir, "srs", "config.toml"))
+
+	var stdout2, stderr2 bytes.Buffer
+	if err := cli.RunInit(configDir, dataDir, true, &stdout2, &stderr2); err != nil {
+		t.Fatalf("second RunInit() with force: %v", err)
+	}
+
+	secondConfig, _ := os.ReadFile(filepath.Join(configDir, "srs", "config.toml"))
+
+	if string(firstConfig) != string(secondConfig) {
+		t.Error("config content differs between first and second run with --force")
+	}
+}
+
+func TestInitSubcommandCreatesFiles(t *testing.T) {
+	configDir := t.TempDir()
+	dataDir := t.TempDir()
+	os.Setenv("XDG_CONFIG_HOME", configDir)
+	os.Setenv("XDG_DATA_HOME", dataDir)
+	defer os.Unsetenv("XDG_CONFIG_HOME")
+	defer os.Unsetenv("XDG_DATA_HOME")
+
+	buf := new(bytes.Buffer)
+	cli.SetOutput(buf)
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"init"})
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("init command failed: %v", err)
+	}
+
+	configPath := filepath.Join(configDir, "srs", "config.toml")
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		t.Error("config.toml not created")
+	}
+	decksRoot := filepath.Join(dataDir, "srs", "decks")
+	if _, err := os.Stat(decksRoot); os.IsNotExist(err) {
+		t.Error("decks_root directory not created")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+	"github.com/jvcorredor/srs-tui/internal/paths"
+)
+
+type PathsConfig struct {
+	DecksRoot string `toml:"decks_root"`
+}
+
+type ReviewConfig struct {
+	NewPerDay int `toml:"new_per_day"`
+}
+
+type EditorConfig struct {
+	Command string `toml:"command"`
+}
+
+type RenderConfig struct {
+	Style string `toml:"style"`
+}
+
+type Config struct {
+	Paths  PathsConfig  `toml:"paths"`
+	Review ReviewConfig `toml:"review"`
+	Editor EditorConfig `toml:"editor"`
+	Render RenderConfig `toml:"render"`
+}
+
+func Defaults() *Config {
+	return &Config{
+		Paths: PathsConfig{
+			DecksRoot: filepath.Join(paths.DataHome(), "srs", "decks"),
+		},
+		Review: ReviewConfig{
+			NewPerDay: 20,
+		},
+		Editor: EditorConfig{
+			Command: "",
+		},
+		Render: RenderConfig{
+			Style: "dark",
+		},
+	}
+}
+
+func Load(configDir string) (*Config, error) {
+	cfg := Defaults()
+	p := filepath.Join(configDir, "srs", "config.toml")
+
+	if _, err := os.Stat(p); os.IsNotExist(err) {
+		return cfg, nil
+	}
+
+	if _, err := toml.DecodeFile(p, cfg); err != nil {
+		return nil, err
+	}
+
+	cfg.Paths.DecksRoot = paths.ExpandHome(cfg.Paths.DecksRoot)
+
+	return cfg, nil
+}
+
+func DefaultConfigContent() string {
+	return `# [paths]
+# decks_root = ""    # Default: $XDG_DATA_HOME/srs/decks
+
+# [review]
+# new_per_day = 20   # New cards per day
+
+# [editor]
+# command = ""       # Editor for card creation (empty = $EDITOR or vi)
+
+# [render]
+# style = "dark"     # dark or light
+`
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,129 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jvcorredor/srs-tui/internal/config"
+)
+
+func TestLoadReturnsDefaultsWhenFileAbsent(t *testing.T) {
+	cfg, err := config.Load(t.TempDir())
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	defaults := config.Defaults()
+	if cfg.Paths.DecksRoot != defaults.Paths.DecksRoot {
+		t.Errorf("Paths.DecksRoot = %q, want %q", cfg.Paths.DecksRoot, defaults.Paths.DecksRoot)
+	}
+	if cfg.Review.NewPerDay != defaults.Review.NewPerDay {
+		t.Errorf("Review.NewPerDay = %d, want %d", cfg.Review.NewPerDay, defaults.Review.NewPerDay)
+	}
+	if cfg.Editor.Command != defaults.Editor.Command {
+		t.Errorf("Editor.Command = %q, want %q", cfg.Editor.Command, defaults.Editor.Command)
+	}
+	if cfg.Render.Style != defaults.Render.Style {
+		t.Errorf("Render.Style = %q, want %q", cfg.Render.Style, defaults.Render.Style)
+	}
+}
+
+func TestLoadParsesV1KeysFromConfigToml(t *testing.T) {
+	dir := t.TempDir()
+	srsDir := filepath.Join(dir, "srs")
+	if err := os.MkdirAll(srsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tomlContent := `[paths]
+decks_root = "/my/custom/decks"
+
+[review]
+new_per_day = 10
+
+[editor]
+command = "vim"
+
+[render]
+style = "light"
+`
+	if err := os.WriteFile(filepath.Join(srsDir, "config.toml"), []byte(tomlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.Paths.DecksRoot != "/my/custom/decks" {
+		t.Errorf("Paths.DecksRoot = %q, want %q", cfg.Paths.DecksRoot, "/my/custom/decks")
+	}
+	if cfg.Review.NewPerDay != 10 {
+		t.Errorf("Review.NewPerDay = %d, want 10", cfg.Review.NewPerDay)
+	}
+	if cfg.Editor.Command != "vim" {
+		t.Errorf("Editor.Command = %q, want %q", cfg.Editor.Command, "vim")
+	}
+	if cfg.Render.Style != "light" {
+		t.Errorf("Render.Style = %q, want %q", cfg.Render.Style, "light")
+	}
+}
+
+func TestLoadPartialConfigKeepsDefaults(t *testing.T) {
+	dir := t.TempDir()
+	srsDir := filepath.Join(dir, "srs")
+	if err := os.MkdirAll(srsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tomlContent := `[review]
+new_per_day = 5
+`
+	if err := os.WriteFile(filepath.Join(srsDir, "config.toml"), []byte(tomlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	defaults := config.Defaults()
+	if cfg.Paths.DecksRoot != defaults.Paths.DecksRoot {
+		t.Errorf("Paths.DecksRoot = %q, want default %q", cfg.Paths.DecksRoot, defaults.Paths.DecksRoot)
+	}
+	if cfg.Review.NewPerDay != 5 {
+		t.Errorf("Review.NewPerDay = %d, want 5", cfg.Review.NewPerDay)
+	}
+	if cfg.Render.Style != defaults.Render.Style {
+		t.Errorf("Render.Style = %q, want default %q", cfg.Render.Style, defaults.Render.Style)
+	}
+}
+
+func TestLoadExpandsTildeInDecksRoot(t *testing.T) {
+	dir := t.TempDir()
+	srsDir := filepath.Join(dir, "srs")
+	if err := os.MkdirAll(srsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tomlContent := `[paths]
+decks_root = "~/my-decks"
+`
+	if err := os.WriteFile(filepath.Join(srsDir, "config.toml"), []byte(tomlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.Load(dir)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, "my-decks")
+	if cfg.Paths.DecksRoot != want {
+		t.Errorf("Paths.DecksRoot = %q, want %q", cfg.Paths.DecksRoot, want)
+	}
+}

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -5,6 +5,14 @@ import (
 	"path/filepath"
 )
 
+func ConfigHome() string {
+	if v := os.Getenv("XDG_CONFIG_HOME"); v != "" {
+		return v
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".config")
+}
+
 func DataHome() string {
 	if v := os.Getenv("XDG_DATA_HOME"); v != "" {
 		return v

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -87,6 +87,28 @@ func TestStateHomeUsesXDGStateHome(t *testing.T) {
 	}
 }
 
+func TestConfigHomeUsesXDGConfigHome(t *testing.T) {
+	custom := filepath.Join(t.TempDir(), "xdg-config")
+	os.Setenv("XDG_CONFIG_HOME", custom)
+	defer os.Unsetenv("XDG_CONFIG_HOME")
+
+	got := paths.ConfigHome()
+	if got != custom {
+		t.Errorf("ConfigHome() = %q, want %q", got, custom)
+	}
+}
+
+func TestConfigHomeFallsBackToDefault(t *testing.T) {
+	os.Unsetenv("XDG_CONFIG_HOME")
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".config")
+
+	got := paths.ConfigHome()
+	if got != want {
+		t.Errorf("ConfigHome() = %q, want %q", got, want)
+	}
+}
+
 func TestStateHomeFallsBackToDefault(t *testing.T) {
 	os.Unsetenv("XDG_STATE_HOME")
 	home, _ := os.UserHomeDir()


### PR DESCRIPTION
## Summary

- Add `srs init` subcommand that scaffolds a default commented `config.toml` under `$XDG_CONFIG_HOME/srs/` and creates an empty `decks_root` directory
- Add `internal/paths.ConfigHome()` for `$XDG_CONFIG_HOME` resolution with `~/.config` fallback
- Add `internal/config` package: `Load`, `Defaults`, `DefaultConfigContent` — loads `config.toml` via `BurntSushi/toml`, expands `~` in `decks_root`, absent config returns implicit defaults
- `init` refuses to overwrite existing config without `--force`; idempotent with `--force`
- Diagnostics to stderr; success summary (paths created) to stdout

Closes: #5