### PR TITLE
feat(cli): add srs new command to create cards from template

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26
 require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/glamour v1.0.0
+	github.com/google/uuid v1.6.0
 	github.com/open-spaced-repetition/go-fsrs/v4 v4.0.0-20260503034430-457418c9bf73
 	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1
@@ -22,7 +23,6 @@ require (
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect

--- a/internal/card/card.go
+++ b/internal/card/card.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
+	"github.com/google/uuid"
 	"gopkg.in/yaml.v3"
 )
 
@@ -40,6 +42,19 @@ type Card struct {
 
 var frontHeading = regexp.MustCompile(`(?m)^## Front\s*$`)
 var backHeading = regexp.MustCompile(`(?m)^## Back\s*$`)
+
+func NewCard(cardType Type, now time.Time) *Card {
+	id, _ := uuid.NewV7()
+	return &Card{
+		Meta: Meta{
+			Schema:  1,
+			ID:      id.String(),
+			Type:    cardType,
+			Created: now.Format(time.RFC3339),
+			Tags:    []string{},
+		},
+	}
+}
 
 func ParseFile(path string) (*Card, error) {
 	data, err := os.ReadFile(path)
@@ -90,6 +105,20 @@ func (c *Card) Serialize() []byte {
 	b.WriteString(c.Back)
 	if !strings.HasSuffix(c.Back, "\n") {
 		b.WriteByte('\n')
+	}
+	return []byte(b.String())
+}
+
+func (c *Card) SerializeNew() []byte {
+	fmData, _ := yaml.Marshal(&c.Meta)
+	var b strings.Builder
+	b.WriteString("---\n")
+	b.Write(fmData)
+	b.WriteString("---\n\n")
+	if c.Type == Cloze {
+		b.WriteString("{{c1::answer}}\n")
+	} else {
+		b.WriteString("## Front\n\n\n\n## Back\n")
 	}
 	return []byte(b.String())
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"time"
 
@@ -16,6 +19,12 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/store"
 	"github.com/jvcorredor/srs-tui/internal/tui"
 )
+
+type UsageError struct {
+	msg string
+}
+
+func (e *UsageError) Error() string { return e.msg }
 
 var (
 	version = "dev"
@@ -41,6 +50,26 @@ var reviewRun ReviewRunFunc = defaultReviewRun
 
 func SetReviewRun(fn ReviewRunFunc) {
 	reviewRun = fn
+}
+
+type EditorRunFunc func(file string) error
+
+var editorRun EditorRunFunc = defaultEditorRun
+
+func SetEditorRun(fn EditorRunFunc) {
+	editorRun = fn
+}
+
+func defaultEditorRun(file string) error {
+	editor := os.Getenv("EDITOR")
+	if editor == "" {
+		editor = "vi"
+	}
+	cmd := exec.Command(editor, file)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }
 
 func MakeRateFunc(s *store.Store) tui.RateFunc {
@@ -111,6 +140,7 @@ func NewRootCmd() *cobra.Command {
 
 	root.AddCommand(newVersionCmd())
 	root.AddCommand(newReviewCmd())
+	root.AddCommand(newNewCmd())
 	return root
 }
 
@@ -128,6 +158,55 @@ func newReviewCmd() *cobra.Command {
 	}
 }
 
+func newNewCmd() *cobra.Command {
+	var cloze bool
+	var decksRoot string
+
+	cmd := &cobra.Command{
+		Use:   "new <deck> <name>",
+		Short: "Create a new card and open it in your editor",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				return &UsageError{msg: fmt.Sprintf("accepts 2 arg(s), received %d", len(args))}
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			deckName := args[0]
+			cardName := args[1]
+
+			root := paths.DecksRoot(decksRoot)
+			deckDir := filepath.Join(root, deckName)
+			cardPath := filepath.Join(deckDir, cardName+".md")
+
+			if _, err := os.Stat(cardPath); err == nil {
+				return fmt.Errorf("new: %s already exists", cardPath)
+			}
+
+			if err := os.MkdirAll(deckDir, 0o755); err != nil {
+				return fmt.Errorf("new: create deck dir: %w", err)
+			}
+
+			cardType := card.Basic
+			if cloze {
+				cardType = card.Cloze
+			}
+			c := card.NewCard(cardType, time.Now())
+
+			if err := store.AtomicWriteFile(cardPath, c.SerializeNew()); err != nil {
+				return fmt.Errorf("new: %w", err)
+			}
+
+			return editorRun(cardPath)
+		},
+	}
+
+	cmd.Flags().BoolVar(&cloze, "cloze", false, "create a cloze-deletion card")
+	cmd.Flags().StringVar(&decksRoot, "decks-root", "", "root directory for decks")
+
+	return cmd
+}
+
 func newVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
@@ -140,8 +219,22 @@ func newVersionCmd() *cobra.Command {
 }
 
 func Execute() int {
+	return ExecuteWithArgs(nil)
+}
+
+func ExecuteWithArgs(args []string) int {
 	root := NewRootCmd()
-	if err := root.Execute(); err != nil {
+	if args != nil {
+		root.SetArgs(args)
+	}
+	root.SetOut(rootOut)
+	root.SetErr(rootOut)
+	err := root.Execute()
+	if err != nil {
+		var usageErr *UsageError
+		if errors.As(err, &usageErr) {
+			return 2
+		}
 		return 1
 	}
 	return 0

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -148,6 +148,198 @@ func TestMakeRateFuncPersistsRating(t *testing.T) {
 	}
 }
 
+func TestNewCommandCreatesCardFileWithPrefilledFrontmatter(t *testing.T) {
+	tmpDir := t.TempDir()
+	cli.SetOutput(io.Discard)
+	cli.SetEditorRun(func(_ string) error { return nil })
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"new", "french", "bonjour", "--decks-root", tmpDir})
+	cmd.SetOut(io.Discard)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("new command failed: %v", err)
+	}
+
+	cardPath := filepath.Join(tmpDir, "french", "bonjour.md")
+	c, err := card.ParseFile(cardPath)
+	if err != nil {
+		t.Fatalf("parse created card: %v", err)
+	}
+	if c.Schema != 1 {
+		t.Errorf("schema = %d, want 1", c.Schema)
+	}
+	if c.ID == "" {
+		t.Error("id should not be empty")
+	}
+	if c.Type != card.Basic {
+		t.Errorf("type = %q, want %q", c.Type, card.Basic)
+	}
+	if c.Created == "" {
+		t.Error("created should not be empty")
+	}
+	if len(c.Tags) != 0 {
+		t.Errorf("tags = %v, want empty", c.Tags)
+	}
+}
+
+func TestNewCommandWithClozeFlagCreatesClozeCard(t *testing.T) {
+	tmpDir := t.TempDir()
+	cli.SetOutput(io.Discard)
+	cli.SetEditorRun(func(_ string) error { return nil })
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"new", "med", "tibia", "--cloze", "--decks-root", tmpDir})
+	cmd.SetOut(io.Discard)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("new command failed: %v", err)
+	}
+
+	cardPath := filepath.Join(tmpDir, "med", "tibia.md")
+	c, err := card.ParseFile(cardPath)
+	if err != nil {
+		t.Fatalf("parse created card: %v", err)
+	}
+	if c.Type != card.Cloze {
+		t.Errorf("type = %q, want %q", c.Type, card.Cloze)
+	}
+
+	raw, err := os.ReadFile(cardPath)
+	if err != nil {
+		t.Fatalf("read card file: %v", err)
+	}
+	if !strings.Contains(string(raw), "{{c1::") {
+		t.Error("cloze card body should contain cloze syntax hint")
+	}
+}
+
+func TestNewCommandRefusesOverwrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	cli.SetOutput(io.Discard)
+	cli.SetEditorRun(func(_ string) error { return nil })
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"new", "french", "bonjour", "--decks-root", tmpDir})
+	cmd.SetOut(io.Discard)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("first new command failed: %v", err)
+	}
+
+	cmd2 := cli.NewRootCmd()
+	cmd2.SetArgs([]string{"new", "french", "bonjour", "--decks-root", tmpDir})
+	cmd2.SetOut(io.Discard)
+	err := cmd2.Execute()
+	if err == nil {
+		t.Fatal("expected error when file already exists")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error should mention 'already exists', got: %v", err)
+	}
+}
+
+func TestNewCommandLaunchesEditor(t *testing.T) {
+	tmpDir := t.TempDir()
+	var editorCalledWith string
+	cli.SetOutput(io.Discard)
+	cli.SetEditorRun(func(file string) error {
+		editorCalledWith = file
+		return nil
+	})
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"new", "french", "bonjour", "--decks-root", tmpDir})
+	cmd.SetOut(io.Discard)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("new command failed: %v", err)
+	}
+
+	cardPath := filepath.Join(tmpDir, "french", "bonjour.md")
+	if editorCalledWith != cardPath {
+		t.Errorf("editor called with %q, want %q", editorCalledWith, cardPath)
+	}
+}
+
+func TestNewCommandCreatesDeckDirectoryIfMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	cli.SetOutput(io.Discard)
+	cli.SetEditorRun(func(_ string) error { return nil })
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"new", "brand-new-deck", "card1", "--decks-root", tmpDir})
+	cmd.SetOut(io.Discard)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("new command failed: %v", err)
+	}
+
+	deckDir := filepath.Join(tmpDir, "brand-new-deck")
+	info, err := os.Stat(deckDir)
+	if err != nil {
+		t.Fatalf("deck directory not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("deck path is not a directory")
+	}
+
+	cardPath := filepath.Join(deckDir, "card1.md")
+	if _, err := os.Stat(cardPath); err != nil {
+		t.Fatalf("card file not created: %v", err)
+	}
+}
+
+func TestNewCommandAtomicWriteNoTmpArtifacts(t *testing.T) {
+	tmpDir := t.TempDir()
+	cli.SetOutput(io.Discard)
+	cli.SetEditorRun(func(_ string) error { return nil })
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"new", "french", "bonjour", "--decks-root", tmpDir})
+	cmd.SetOut(io.Discard)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("new command failed: %v", err)
+	}
+
+	deckDir := filepath.Join(tmpDir, "french")
+	entries, err := os.ReadDir(deckDir)
+	if err != nil {
+		t.Fatalf("read deck dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("temp artifact left behind: %s", e.Name())
+		}
+	}
+}
+
+func TestNewCommandUsageErrorReturnsExitCode2(t *testing.T) {
+	cli.SetOutput(io.Discard)
+	code := cli.ExecuteWithArgs([]string{"new"})
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2 for usage error", code)
+	}
+}
+
+func TestNewCommandRuntimeErrorReturnsExitCode1(t *testing.T) {
+	tmpDir := t.TempDir()
+	cli.SetOutput(io.Discard)
+	cli.SetEditorRun(func(_ string) error { return nil })
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"new", "french", "bonjour", "--decks-root", tmpDir})
+	cmd.SetOut(io.Discard)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("first new command failed: %v", err)
+	}
+
+	code := cli.ExecuteWithArgs([]string{"new", "french", "bonjour", "--decks-root", tmpDir})
+	if code != 1 {
+		t.Errorf("exit code = %d, want 1 for runtime error (file exists)", code)
+	}
+}
+
 func TestMakeRateFuncAssignsID(t *testing.T) {
 	cardDir := t.TempDir()
 	stateDir := t.TempDir()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -59,33 +59,37 @@ func (s *Store) AppendLog(entry LogEntry) error {
 	return f.Sync()
 }
 
-func (s *Store) RewriteCard(cardPath string, c *card.Card) error {
-	dir := filepath.Dir(cardPath)
+func AtomicWriteFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
 	tmp, err := os.CreateTemp(dir, "*.tmp")
 	if err != nil {
-		return fmt.Errorf("store: create temp: %w", err)
+		return fmt.Errorf("atomic write: create temp: %w", err)
 	}
 	tmpPath := tmp.Name()
 
-	if _, err := tmp.Write(c.Serialize()); err != nil {
+	if _, err := tmp.Write(data); err != nil {
 		tmp.Close()
 		os.Remove(tmpPath)
-		return fmt.Errorf("store: write temp: %w", err)
+		return fmt.Errorf("atomic write: write temp: %w", err)
 	}
 	if err := tmp.Sync(); err != nil {
 		tmp.Close()
 		os.Remove(tmpPath)
-		return fmt.Errorf("store: sync temp: %w", err)
+		return fmt.Errorf("atomic write: sync temp: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
 		os.Remove(tmpPath)
-		return fmt.Errorf("store: close temp: %w", err)
+		return fmt.Errorf("atomic write: close temp: %w", err)
 	}
-	if err := os.Rename(tmpPath, cardPath); err != nil {
+	if err := os.Rename(tmpPath, path); err != nil {
 		os.Remove(tmpPath)
-		return fmt.Errorf("store: rename temp: %w", err)
+		return fmt.Errorf("atomic write: rename temp: %w", err)
 	}
 	return nil
+}
+
+func (s *Store) RewriteCard(cardPath string, c *card.Card) error {
+	return AtomicWriteFile(cardPath, c.Serialize())
 }
 
 func (s *Store) Persist(entry LogEntry, cardPath string, c *card.Card) error {


### PR DESCRIPTION
## Summary

- Adds `srs new <deck> <name>` subcommand that creates a card file with prefilled frontmatter and opens it in `$EDITOR`
- Supports `--cloze` flag for cloze-deletion cards and `--decks-root` for custom deck location
- Refuses overwrite of existing files, uses atomic write (temp + rename), returns exit code 2 for usage errors
- Extracts `store.AtomicWriteFile` as shared helper (used by both `new` command and `RewriteCard`)
- Adds `card.NewCard` constructor and `card.SerializeNew` for template generation

Closes: #6