### PR TITLE
feat(version): three-tier version resolution with JSON output

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -19,6 +20,7 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/paths"
 	"github.com/jvcorredor/srs-tui/internal/store"
 	"github.com/jvcorredor/srs-tui/internal/tui"
+	"github.com/jvcorredor/srs-tui/internal/version"
 )
 
 type UsageError struct {
@@ -26,18 +28,6 @@ type UsageError struct {
 }
 
 func (e *UsageError) Error() string { return e.msg }
-
-var (
-	version = "dev"
-	commit  = "none"
-	date    = "unknown"
-)
-
-func SetVersion(v, c, d string) {
-	version = v
-	commit = c
-	date = d
-}
 
 func SetOutput(w io.Writer) {
 	rootOut = w
@@ -210,14 +200,26 @@ func newNewCmd() *cobra.Command {
 }
 
 func newVersionCmd() *cobra.Command {
-	return &cobra.Command{
+	var format string
+	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print version info",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Fprintf(cmd.OutOrStdout(), "srs %s\ncommit: %s\ndate:   %s\n", version, commit, date)
+			info := version.Get()
+			switch format {
+			case "text":
+				fmt.Fprintf(cmd.OutOrStdout(), "srs %s\ncommit: %s\ndate:   %s\n", info.Version, info.Commit, info.Date)
+			case "json":
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				return enc.Encode(info)
+			default:
+				return &UsageError{msg: fmt.Sprintf("--format: must be \"text\" or \"json\", got %q", format)}
+			}
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&format, "format", "text", `output format: "text" or "json"`)
+	return cmd
 }
 
 func newInitCmd() *cobra.Command {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"testing"
 	"time"
@@ -15,12 +16,16 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/cli"
 	"github.com/jvcorredor/srs-tui/internal/fsrs"
 	"github.com/jvcorredor/srs-tui/internal/store"
+	"github.com/jvcorredor/srs-tui/internal/version"
 )
 
+func noBuildInfo() (*debug.BuildInfo, bool) { return nil, false }
+
 func TestVersionCommandPrintsVersion(t *testing.T) {
+	defer version.SwapForTest("0.0.0-dev", "abc1234", "2026-01-01", noBuildInfo)()
+
 	buf := new(bytes.Buffer)
 	cli.SetOutput(buf)
-	cli.SetVersion("0.0.0-dev", "abc1234", "2026-01-01")
 
 	cmd := cli.NewRootCmd()
 	cmd.SetArgs([]string{"version"})
@@ -39,6 +44,48 @@ func TestVersionCommandPrintsVersion(t *testing.T) {
 	}
 	if !strings.Contains(out, "2026-01-01") {
 		t.Errorf("version output missing date: got %q", out)
+	}
+}
+
+func TestVersionCommandJSONFormat(t *testing.T) {
+	defer version.SwapForTest("v0.2.0", "abc1234", "2026-05-03T12:00:00Z", noBuildInfo)()
+
+	buf := new(bytes.Buffer)
+	cli.SetOutput(buf)
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"version", "--format=json"})
+	cmd.SetOut(buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("version --format=json failed: %v", err)
+	}
+
+	var got version.Info
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput=%q", err, buf.String())
+	}
+
+	want := version.Info{Version: "v0.2.0", Commit: "abc1234", Date: "2026-05-03T12:00:00Z", Source: "ldflags"}
+	if got != want {
+		t.Errorf("Info = %+v, want %+v", got, want)
+	}
+}
+
+func TestVersionCommandRejectsUnknownFormat(t *testing.T) {
+	defer version.SwapForTest("v0.2.0", "abc", "2026-05-03", noBuildInfo)()
+
+	buf := new(bytes.Buffer)
+	cli.SetOutput(buf)
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"version", "--format=yaml"})
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for unknown --format value")
 	}
 }
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,54 @@
+// Package version resolves the running binary's version, commit, and build
+// date through three tiers: ldflags-injected vars, runtime/debug.BuildInfo
+// (for go install @version), or sentinel defaults.
+package version
+
+import "runtime/debug"
+
+var (
+	Version string
+	Commit  string
+	Date    string
+)
+
+var readBuildInfo = debug.ReadBuildInfo
+
+type Info struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+	Date    string `json:"date"`
+	Source  string `json:"source"`
+}
+
+func Get() Info {
+	if Version != "" {
+		return Info{Version: Version, Commit: Commit, Date: Date, Source: "ldflags"}
+	}
+
+	if bi, ok := readBuildInfo(); ok && bi.Main.Version != "" && bi.Main.Version != "(devel)" {
+		info := Info{Version: bi.Main.Version, Commit: "unknown", Date: "unknown", Source: "buildinfo"}
+		for _, s := range bi.Settings {
+			switch s.Key {
+			case "vcs.revision":
+				info.Commit = s.Value
+			case "vcs.time":
+				info.Date = s.Value
+			}
+		}
+		return info
+	}
+
+	return Info{Version: "dev", Commit: "unknown", Date: "unknown", Source: "default"}
+}
+
+// SwapForTest replaces the package-level resolution inputs and returns a
+// restore function. Test-only — never call from production code.
+func SwapForTest(v, c, d string, rbi func() (*debug.BuildInfo, bool)) func() {
+	prevV, prevC, prevD, prevRBI := Version, Commit, Date, readBuildInfo
+	Version, Commit, Date = v, c, d
+	readBuildInfo = rbi
+	return func() {
+		Version, Commit, Date = prevV, prevC, prevD
+		readBuildInfo = prevRBI
+	}
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,124 @@
+package version_test
+
+import (
+	"encoding/json"
+	"runtime/debug"
+	"testing"
+
+	"github.com/jvcorredor/srs-tui/internal/version"
+)
+
+func TestGetReturnsSentinelDefaultsWhenNothingResolved(t *testing.T) {
+	defer version.SwapForTest("", "", "", func() (*debug.BuildInfo, bool) { return nil, false })()
+
+	got := version.Get()
+
+	if got.Version != "dev" {
+		t.Errorf("Version = %q, want %q", got.Version, "dev")
+	}
+	if got.Commit != "unknown" {
+		t.Errorf("Commit = %q, want %q", got.Commit, "unknown")
+	}
+	if got.Date != "unknown" {
+		t.Errorf("Date = %q, want %q", got.Date, "unknown")
+	}
+	if got.Source != "default" {
+		t.Errorf("Source = %q, want %q", got.Source, "default")
+	}
+}
+
+func TestGetUsesLdflagsValuesWhenSet(t *testing.T) {
+	defer version.SwapForTest("v1.2.3", "abc1234", "2026-05-03T12:00:00Z", func() (*debug.BuildInfo, bool) {
+		t.Fatal("readBuildInfo should not be consulted when ldflags vars are set")
+		return nil, false
+	})()
+
+	got := version.Get()
+
+	if got.Version != "v1.2.3" {
+		t.Errorf("Version = %q, want %q", got.Version, "v1.2.3")
+	}
+	if got.Commit != "abc1234" {
+		t.Errorf("Commit = %q, want %q", got.Commit, "abc1234")
+	}
+	if got.Date != "2026-05-03T12:00:00Z" {
+		t.Errorf("Date = %q, want %q", got.Date, "2026-05-03T12:00:00Z")
+	}
+	if got.Source != "ldflags" {
+		t.Errorf("Source = %q, want %q", got.Source, "ldflags")
+	}
+}
+
+func TestGetReadsBuildInfoWhenLdflagsEmpty(t *testing.T) {
+	fixture := &debug.BuildInfo{
+		Main: debug.Module{Version: "v0.5.1"},
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "deadbeefcafe"},
+			{Key: "vcs.time", Value: "2026-04-01T08:30:00Z"},
+		},
+	}
+	defer version.SwapForTest("", "", "", func() (*debug.BuildInfo, bool) { return fixture, true })()
+
+	got := version.Get()
+
+	if got.Version != "v0.5.1" {
+		t.Errorf("Version = %q, want %q", got.Version, "v0.5.1")
+	}
+	if got.Commit != "deadbeefcafe" {
+		t.Errorf("Commit = %q, want %q", got.Commit, "deadbeefcafe")
+	}
+	if got.Date != "2026-04-01T08:30:00Z" {
+		t.Errorf("Date = %q, want %q", got.Date, "2026-04-01T08:30:00Z")
+	}
+	if got.Source != "buildinfo" {
+		t.Errorf("Source = %q, want %q", got.Source, "buildinfo")
+	}
+}
+
+func TestGetUsesDefaultsWhenBuildInfoMainVersionDevel(t *testing.T) {
+	fixture := &debug.BuildInfo{
+		Main: debug.Module{Version: "(devel)"},
+	}
+	defer version.SwapForTest("", "", "", func() (*debug.BuildInfo, bool) { return fixture, true })()
+
+	got := version.Get()
+
+	if got.Source != "default" {
+		t.Errorf("Source = %q, want %q (Main.Version=(devel) should fall through)", got.Source, "default")
+	}
+	if got.Version != "dev" {
+		t.Errorf("Version = %q, want %q", got.Version, "dev")
+	}
+}
+
+func TestInfoJSONRoundTrip(t *testing.T) {
+	original := version.Info{
+		Version: "v0.2.0",
+		Commit:  "1234abcd",
+		Date:    "2026-05-03T12:00:00Z",
+		Source:  "ldflags",
+	}
+
+	raw, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var asMap map[string]string
+	if err := json.Unmarshal(raw, &asMap); err != nil {
+		t.Fatalf("Unmarshal to map: %v", err)
+	}
+	for _, key := range []string{"version", "commit", "date", "source"} {
+		if _, ok := asMap[key]; !ok {
+			t.Errorf("JSON missing %q key, got: %s", key, raw)
+		}
+	}
+
+	var roundTripped version.Info
+	if err := json.Unmarshal(raw, &roundTripped); err != nil {
+		t.Fatalf("Unmarshal to Info: %v", err)
+	}
+	if roundTripped != original {
+		t.Errorf("round trip mismatch: got %+v, want %+v", roundTripped, original)
+	}
+}


### PR DESCRIPTION
## Summary

- New `internal/version` package with `Get() Info`. Three-tier resolution: ldflags vars → `runtime/debug.BuildInfo` (for `go install @version`) → sentinel defaults. `Info.Source` records which tier won (`"ldflags"` / `"buildinfo"` / `"default"`).
- `srs version` rewritten to call `version.Get()` and accept `--format={text,json}`. JSON contract: `{"version","commit","date","source"}`.
- Removed `cli.SetVersion` and the inline `version`/`commit`/`date` vars. Release ldflags should now target `github.com/jvcorredor/srs-tui/internal/version.{Version,Commit,Date}`.

Closes #18. Part of #16.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `go vet ./...` — clean
- [x] `version` package tests cover all three resolution branches + the `(devel)` Main.Version edge case + JSON round-trip
- [x] CLI tests adapted: `TestVersionCommandPrintsVersion` uses `version.SwapForTest`; new `TestVersionCommandJSONFormat` and `TestVersionCommandRejectsUnknownFormat`
- [x] Smoke test: `srs version` (text), `srs version --format=json` (JSON), `srs version --format=yaml` (UsageError, exit 2)
- [x] Smoke test: `go build -ldflags "-X .../internal/version.Version=v0.2.0 ..."` produces JSON with `"source":"ldflags"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)