### PR TITLE
docs(internal/fsrs): add Go doc comments to package and tests

### DIFF
--- a/internal/fsrs/fsrs.go
+++ b/internal/fsrs/fsrs.go
@@ -1,3 +1,6 @@
+// Package fsrs provides scheduling logic for spaced-repetition cards using the
+// FSRS (Free Spaced Repetition Scheduler) algorithm. It wraps the open-spaced-repetition
+// go-fsrs library with domain-specific types and helpers used by the application.
 package fsrs
 
 import (
@@ -7,24 +10,32 @@ import (
 	fsrslib "github.com/open-spaced-repetition/go-fsrs/v4"
 )
 
+// State represents the learning stage of a card in the FSRS algorithm.
 type State string
 
 const (
-	StateNew        State = "new"
-	StateLearning   State = "learning"
-	StateReview     State = "review"
+	// StateNew indicates the card has never been reviewed.
+	StateNew State = "new"
+	// StateLearning indicates the card is in the initial learning phase.
+	StateLearning State = "learning"
+	// StateReview indicates the card is in the regular review phase.
+	StateReview State = "review"
+	// StateRelearning indicates the card has lapsed and is being re-learned.
 	StateRelearning State = "relearning"
 )
 
+// CardState holds the scheduling state of a card at a point in time.
 type CardState struct {
 	State      State
-	Due       time.Time
+	Due        time.Time
 	Stability  float64
 	Difficulty float64
-	Reps      int
-	Lapses    int
+	Reps       int
+	Lapses     int
 }
 
+// IntervalPreview shows the projected next state and interval for a given
+// user rating without actually updating the card.
 type IntervalPreview struct {
 	Rating   int
 	State    State
@@ -32,6 +43,7 @@ type IntervalPreview struct {
 	Interval time.Duration
 }
 
+// stateFromLib converts a go-fsrs State to the package State type.
 func stateFromLib(s fsrslib.State) State {
 	switch s {
 	case fsrslib.New:
@@ -46,6 +58,7 @@ func stateFromLib(s fsrslib.State) State {
 	return ""
 }
 
+// stateToLib converts a package State to the go-fsrs State type.
 func stateToLib(s State) fsrslib.State {
 	switch s {
 	case StateNew:
@@ -60,6 +73,7 @@ func stateToLib(s State) fsrslib.State {
 	return fsrslib.New
 }
 
+// toLibCard converts a CardState to the go-fsrs Card type.
 func toLibCard(c CardState) fsrslib.Card {
 	return fsrslib.Card{
 		Due:        c.Due,
@@ -71,19 +85,25 @@ func toLibCard(c CardState) fsrslib.Card {
 	}
 }
 
+// fromLibCard converts a go-fsrs Card to the package CardState type.
 func fromLibCard(c fsrslib.Card) CardState {
 	return CardState{
 		State:      stateFromLib(c.State),
-		Due:       c.Due,
+		Due:        c.Due,
 		Stability:  c.Stability,
 		Difficulty: c.Difficulty,
-		Reps:      int(c.Reps),
-		Lapses:    int(c.Lapses),
+		Reps:       int(c.Reps),
+		Lapses:     int(c.Lapses),
 	}
 }
 
+// defaultFSRS is the shared FSRS scheduler instance configured with default
+// parameters.
 var defaultFSRS = fsrslib.NewFSRS(fsrslib.DefaultParam())
 
+// Preview returns the possible next states and intervals for a card if it were
+// reviewed right now. The returned slice contains one entry for each of the
+// four FSRS ratings (Again, Hard, Good, Easy). It does not modify the card.
 func Preview(card CardState, now time.Time) []IntervalPreview {
 	libCard := toLibCard(card)
 	log := defaultFSRS.Repeat(libCard, now)
@@ -108,6 +128,8 @@ func Preview(card CardState, now time.Time) []IntervalPreview {
 	return previews
 }
 
+// ParseTime parses an RFC3339 string into a time.Time. It returns the zero
+// value for an empty string or on parse failure.
 func ParseTime(s string) time.Time {
 	if s == "" {
 		return time.Time{}
@@ -116,6 +138,8 @@ func ParseTime(s string) time.Time {
 	return t
 }
 
+// NormalizeState converts a raw string into a State. It returns StateNew for
+// an empty string.
 func NormalizeState(s string) State {
 	if s == "" {
 		return StateNew
@@ -123,6 +147,9 @@ func NormalizeState(s string) State {
 	return State(s)
 }
 
+// Rate applies a user rating (1–4) to a card at the given time and returns the
+// updated card state, a preview of all four rating outcomes, and any error.
+// Rating values map to FSRS: 1 = Again, 2 = Hard, 3 = Good, 4 = Easy.
 func Rate(card CardState, rating int, now time.Time) (CardState, []IntervalPreview, error) {
 	if rating < 1 || rating > 4 {
 		return CardState{}, nil, fmt.Errorf("fsrs: rating %d out of range [1,4]", rating)

--- a/internal/fsrs/fsrs_test.go
+++ b/internal/fsrs/fsrs_test.go
@@ -1,3 +1,6 @@
+// Package fsrs_test contains integration-style tests for the fsrs scheduling
+// package. Tests exercise the public API (Preview, Rate, NormalizeState) and
+// verify behaviour through exported types rather than implementation details.
 package fsrs_test
 
 import (
@@ -7,6 +10,8 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/fsrs"
 )
 
+// TestRateNewCardReturnsNextStateAndPreviews checks that rating a new card
+// produces a non-empty next state, positive stability, and four preview entries.
 func TestRateNewCardReturnsNextStateAndPreviews(t *testing.T) {
 	card := fsrs.CardState{State: fsrs.StateNew}
 	now := time.Now()
@@ -34,6 +39,8 @@ func TestRateNewCardReturnsNextStateAndPreviews(t *testing.T) {
 	}
 }
 
+// TestRateNewCardAgainGoesToLearning verifies that rating a new card Again
+// (rating 1) moves it to the learning state.
 func TestRateNewCardAgainGoesToLearning(t *testing.T) {
 	card := fsrs.CardState{State: fsrs.StateNew}
 	now := time.Now()
@@ -47,6 +54,8 @@ func TestRateNewCardAgainGoesToLearning(t *testing.T) {
 	}
 }
 
+// TestRateNewCardGoodGoesToLearning verifies that rating a new card Good
+// (rating 3) moves it to the learning state.
 func TestRateNewCardGoodGoesToLearning(t *testing.T) {
 	card := fsrs.CardState{State: fsrs.StateNew}
 	now := time.Now()
@@ -60,6 +69,8 @@ func TestRateNewCardGoodGoesToLearning(t *testing.T) {
 	}
 }
 
+// TestRateNewCardEasyGoesToReview verifies that rating a new card Easy
+// (rating 4) skips learning and moves it directly to the review state.
 func TestRateNewCardEasyGoesToReview(t *testing.T) {
 	card := fsrs.CardState{State: fsrs.StateNew}
 	now := time.Now()
@@ -73,6 +84,8 @@ func TestRateNewCardEasyGoesToReview(t *testing.T) {
 	}
 }
 
+// TestPreviewReturnsFourIntervals ensures Preview returns one entry for each
+// of the four FSRS ratings and that all intervals are non-negative.
 func TestPreviewReturnsFourIntervals(t *testing.T) {
 	card := fsrs.CardState{State: fsrs.StateNew}
 	now := time.Now()
@@ -95,6 +108,8 @@ func TestPreviewReturnsFourIntervals(t *testing.T) {
 	}
 }
 
+// TestNormalizeState checks that empty strings map to StateNew and that
+// known state strings are preserved.
 func TestNormalizeState(t *testing.T) {
 	if fsrs.NormalizeState("") != fsrs.StateNew {
 		t.Errorf("NormalizeState(\"\") = %q, want %q", fsrs.NormalizeState(""), fsrs.StateNew)


### PR DESCRIPTION
## Summary

Add comprehensive Go doc comments to `internal/fsrs` and its test file to satisfy `go doc` and `go vet`.

## Changes

- **Package comment** describing the FSRS scheduling wrapper.
- **Exported types** (`CardState`, `IntervalPreview`, `State`) with field-level comments on constants.
- **Exported functions** (`Preview`, `Rate`, `ParseTime`, `NormalizeState`) documenting behavior, parameters, and return values.
- **Unexported helpers** (`stateFromLib`, `stateToLib`, `toLibCard`, `fromLibCard`, `defaultFSRS`) with concise purpose comments.
- **Test file** package comment and per-test function comments explaining what each test verifies.

## Verification

- `go doc ./internal/fsrs` shows useful package-level documentation.
- `go vet ./internal/fsrs` passes cleanly.
- `go test ./internal/fsrs` passes.

Closes: #28