### PR TITLE
docs(card): document card file model package

### DIFF
--- a/internal/card/card.go
+++ b/internal/card/card.go
@@ -1,3 +1,8 @@
+// Package card implements the Markdown card file model used by srs-tui.
+//
+// A card is stored as a Markdown file with YAML frontmatter followed by
+// ## Front and ## Back sections. The frontmatter contains metadata such as
+// ID, type, creation time, and FSRS scheduling fields.
 package card
 
 import (
@@ -12,13 +17,17 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Type describes the kind of card.
 type Type string
 
 const (
+	// Basic is a standard question/answer card.
 	Basic Type = "basic"
+	// Cloze is a fill-in-the-blank card.
 	Cloze Type = "cloze"
 )
 
+// Meta holds the YAML frontmatter for a card.
 type Meta struct {
 	Schema     int      `yaml:"schema"`
 	ID         string   `yaml:"id"`
@@ -33,6 +42,7 @@ type Meta struct {
 	Lapses     int      `yaml:"lapses,omitempty"`
 }
 
+// Card represents a spaced-repetition card backed by a Markdown file.
 type Card struct {
 	Meta
 	Front    string
@@ -43,6 +53,7 @@ type Card struct {
 var frontHeading = regexp.MustCompile(`(?m)^## Front\s*$`)
 var backHeading = regexp.MustCompile(`(?m)^## Back\s*$`)
 
+// NewCard creates a new card with a generated UUID v7 and the given type.
 func NewCard(cardType Type, now time.Time) *Card {
 	id, _ := uuid.NewV7()
 	return &Card{
@@ -56,6 +67,8 @@ func NewCard(cardType Type, now time.Time) *Card {
 	}
 }
 
+// ParseFile reads a Markdown card file and parses it into a Card.
+// The file path is recorded in the returned Card's FilePath field.
 func ParseFile(path string) (*Card, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -71,6 +84,8 @@ func ParseFile(path string) (*Card, error) {
 	return c, nil
 }
 
+// Parse converts raw Markdown bytes into a Card.
+// If the data has no frontmatter or no ID, it returns nil, nil.
 func Parse(data []byte) (*Card, error) {
 	fm, body, err := splitFrontmatter(data)
 	if err != nil {
@@ -90,6 +105,8 @@ func Parse(data []byte) (*Card, error) {
 	}, nil
 }
 
+// Serialize writes the card back to its Markdown representation,
+// including YAML frontmatter and Front/Back sections.
 func (c *Card) Serialize() []byte {
 	fmData, _ := yaml.Marshal(&c.Meta)
 	var b strings.Builder
@@ -109,6 +126,9 @@ func (c *Card) Serialize() []byte {
 	return []byte(b.String())
 }
 
+// SerializeNew returns a minimal Markdown template for a newly created card.
+// For cloze cards it includes a placeholder; for basic cards it provides
+// empty Front and Back headings.
 func (c *Card) SerializeNew() []byte {
 	fmData, _ := yaml.Marshal(&c.Meta)
 	var b strings.Builder
@@ -123,6 +143,8 @@ func (c *Card) SerializeNew() []byte {
 	return []byte(b.String())
 }
 
+// splitFrontmatter extracts the YAML frontmatter and the remaining body from data.
+// If there is no frontmatter, it returns nil, data, nil.
 func splitFrontmatter(data []byte) (*Meta, []byte, error) {
 	if !bytes.HasPrefix(data, []byte("---\n")) {
 		return nil, data, nil
@@ -141,6 +163,8 @@ func splitFrontmatter(data []byte) (*Meta, []byte, error) {
 	return &meta, body, nil
 }
 
+// splitBody extracts the front and back text from the Markdown body
+// by looking for ## Front and ## Back headings.
 func splitBody(body string) (front, back string) {
 	loc := frontHeading.FindStringIndex(body)
 	if loc != nil {

--- a/internal/card/card_test.go
+++ b/internal/card/card_test.go
@@ -1,3 +1,6 @@
+// Package card_test contains integration tests for the card package.
+// Tests exercise the public API (Parse, ParseFile, Serialize, SerializeNew)
+// through real file I/O and round-trip validation.
 package card_test
 
 import (


### PR DESCRIPTION
## Summary

Add Go doc comments to `internal/card` and `internal/card_test` to document the card file model package.

## Changes

- Package comment explaining the Markdown card file structure (YAML frontmatter + Front/Back sections)
- Doc comments on all exported types: `Card`, `Meta`, `Type`
- Doc comments on all exported functions: `NewCard`, `ParseFile`, `Parse`, `Serialize`, `SerializeNew`
- Doc comments on unexported helpers: `splitFrontmatter`, `splitBody`
- Doc comments on constants `Basic` and `Cloze`
- Package comment in `card_test.go` describing the integration test strategy

## Verification

- `go doc ./internal/card` shows the package comment and all documented symbols
- `go vet ./internal/card` passes cleanly
- `go test ./internal/card` passes

Refs: #29