### PR TITLE
docs(internal): add package comments for config, paths, and cmd/srs

### DIFF
--- a/cmd/srs/main.go
+++ b/cmd/srs/main.go
@@ -1,3 +1,8 @@
+// srs is a terminal UI for spaced-repetition flashcards.
+//
+// It exposes sub-commands for reviewing decks, creating cards, and
+// managing configuration.  The real logic lives in internal/cli; this
+// file is the minimal entry point that delegates to it.
 package main
 
 import (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,10 @@
+// Package config loads and provides application settings for srs-tui.
+//
+// Configuration is read from a TOML file located at
+// <config-dir>/srs/config.toml, where <config-dir> defaults to
+// $XDG_CONFIG_HOME or ~/.config.  When the file is missing, Load
+// returns the built-in defaults.  All settings are optional; any
+// key omitted from the file keeps its default value.
 package config
 
 import (
@@ -8,22 +15,27 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/paths"
 )
 
+// PathsConfig holds directory-path settings.
 type PathsConfig struct {
 	DecksRoot string `toml:"decks_root"`
 }
 
+// ReviewConfig holds review-session settings.
 type ReviewConfig struct {
 	NewPerDay int `toml:"new_per_day"`
 }
 
+// EditorConfig holds external-editor settings.
 type EditorConfig struct {
 	Command string `toml:"command"`
 }
 
+// RenderConfig holds TUI rendering settings.
 type RenderConfig struct {
 	Style string `toml:"style"`
 }
 
+// Config is the top-level configuration aggregate.
 type Config struct {
 	Paths  PathsConfig  `toml:"paths"`
 	Review ReviewConfig `toml:"review"`
@@ -31,6 +43,7 @@ type Config struct {
 	Render RenderConfig `toml:"render"`
 }
 
+// Defaults returns a Config populated with built-in defaults.
 func Defaults() *Config {
 	return &Config{
 		Paths: PathsConfig{
@@ -48,6 +61,10 @@ func Defaults() *Config {
 	}
 }
 
+// Load reads config.toml from <configDir>/srs and returns the merged
+// result.  Missing files are treated as an empty config, so defaults
+// are always preserved.  Tilde characters in DecksRoot are expanded
+// to the user's home directory.
 func Load(configDir string) (*Config, error) {
 	cfg := Defaults()
 	p := filepath.Join(configDir, "srs", "config.toml")
@@ -65,6 +82,8 @@ func Load(configDir string) (*Config, error) {
 	return cfg, nil
 }
 
+// DefaultConfigContent returns the text embedded in a newly scaffolded
+// config.toml file, including commented documentation for every section.
 func DefaultConfigContent() string {
 	return `# [paths]
 # decks_root = ""    # Default: $XDG_DATA_HOME/srs/decks

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,3 +1,4 @@
+// Package config_test contains unit tests for the config loader.
 package config_test
 
 import (

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -1,3 +1,6 @@
+// Package paths resolves directories according to the XDG Base Directory
+// specification, providing sensible fallbacks when the environment variables
+// are unset.
 package paths
 
 import (
@@ -5,6 +8,8 @@ import (
 	"path/filepath"
 )
 
+// ConfigHome returns the XDG configuration directory ($XDG_CONFIG_HOME,
+// or ~/.config by default).
 func ConfigHome() string {
 	if v := os.Getenv("XDG_CONFIG_HOME"); v != "" {
 		return v
@@ -13,6 +18,8 @@ func ConfigHome() string {
 	return filepath.Join(home, ".config")
 }
 
+// DataHome returns the XDG data directory ($XDG_DATA_HOME, or
+// ~/.local/share by default).
 func DataHome() string {
 	if v := os.Getenv("XDG_DATA_HOME"); v != "" {
 		return v
@@ -21,6 +28,8 @@ func DataHome() string {
 	return filepath.Join(home, ".local", "share")
 }
 
+// StateHome returns the XDG state directory ($XDG_STATE_HOME, or
+// ~/.local/state by default).
 func StateHome() string {
 	if v := os.Getenv("XDG_STATE_HOME"); v != "" {
 		return v
@@ -29,6 +38,9 @@ func StateHome() string {
 	return filepath.Join(home, ".local", "state")
 }
 
+// DecksRoot returns the root directory for deck storage.  If override is
+// non-empty it is used verbatim (with tilde expansion); otherwise the
+// default $XDG_DATA_HOME/srs/decks is returned.
 func DecksRoot(override string) string {
 	if override != "" {
 		return ExpandHome(override)
@@ -36,6 +48,7 @@ func DecksRoot(override string) string {
 	return filepath.Join(DataHome(), "srs", "decks")
 }
 
+// ExpandHome replaces a leading "~" in p with the user's home directory.
 func ExpandHome(p string) string {
 	if len(p) > 0 && p[0] == '~' {
 		home, _ := os.UserHomeDir()

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -1,3 +1,4 @@
+// Package paths_test contains unit tests for XDG path resolution.
 package paths_test
 
 import (


### PR DESCRIPTION
## Summary

Adds Go doc comments to the infrastructure packages (`internal/config`, `internal/paths`) and the CLI entry point (`cmd/srs/main.go`) to make them friendly for `go doc`.

- `internal/config`: paragraph-level package comment explaining TOML config loading, defaults, and path resolution. Also adds doc comments on exported types and functions.
- `internal/paths`: one-line package comment about XDG Base Directory resolution. Also adds doc comments on all exported functions.
- `cmd/srs/main.go`: file-level comment describing the CLI entry point.
- Test files: brief package comments for `config_test` and `paths_test`.

## Verification

- `go doc ./internal/config` — shows paragraph-length package comment ✅
- `go doc ./internal/paths` — shows one-line package comment ✅
- `go doc ./cmd/srs` — shows file-level comment ✅
- `go vet ./internal/config ./internal/paths ./cmd/srs` — passes ✅

Closes #30