### PR TITLE
docs(deck,store): add Go doc comments to packages and tests

### DIFF
--- a/internal/deck/deck.go
+++ b/internal/deck/deck.go
@@ -1,3 +1,5 @@
+// Package deck discovers SRS decks on disk and builds shuffled review queues
+// from the Markdown card files contained within each deck directory.
 package deck
 
 import (
@@ -8,6 +10,9 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/card"
 )
 
+// Discover returns the absolute paths of every immediate subdirectory inside
+// root. Only directories are returned; regular files are ignored. Symlinks to
+// directories are followed.
 func Discover(root string) ([]string, error) {
 	entries, err := os.ReadDir(root)
 	if err != nil {
@@ -27,6 +32,9 @@ func Discover(root string) ([]string, error) {
 	return decks, nil
 }
 
+// BuildQueue walks deckDir recursively, parses every .md file into a Card,
+// and returns the collected cards in random order. Files that cannot be
+// parsed as cards or that lack frontmatter are skipped.
 func BuildQueue(deckDir string) ([]*card.Card, error) {
 	var cards []*card.Card
 	err := filepath.WalkDir(deckDir, func(path string, d os.DirEntry, err error) error {

--- a/internal/deck/deck_test.go
+++ b/internal/deck/deck_test.go
@@ -1,3 +1,6 @@
+// Package deck_test contains integration tests for the deck package.
+// Tests exercise the public API (Discover, BuildQueue) through real
+// filesystem operations in temporary directories.
 package deck_test
 
 import (
@@ -10,6 +13,7 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/deck"
 )
 
+// writeBasicCard creates a minimal valid card file in dir named id+".md".
 func writeBasicCard(t *testing.T, dir, id, front, back string) {
 	t.Helper()
 	c := &card.Card{
@@ -28,6 +32,8 @@ func writeBasicCard(t *testing.T, dir, id, front, back string) {
 	}
 }
 
+// TestDiscoverDecks verifies that Discover returns only immediate
+// subdirectories and ignores regular files.
 func TestDiscoverDecks(t *testing.T) {
 	root := t.TempDir()
 	os.MkdirAll(filepath.Join(root, "french"), 0o755)
@@ -57,6 +63,8 @@ func TestDiscoverDecks(t *testing.T) {
 	}
 }
 
+// TestDiscoverFollowsSymlinks checks that symlinked directories are
+// included in the discovered deck list.
 func TestDiscoverFollowsSymlinks(t *testing.T) {
 	root := t.TempDir()
 	realDir := t.TempDir()
@@ -82,6 +90,8 @@ func TestDiscoverFollowsSymlinks(t *testing.T) {
 	}
 }
 
+// TestQueueContainsAllCardsShuffled confirms that BuildQueue finds every
+// card in the deck and returns them in a shuffled order.
 func TestQueueContainsAllCardsShuffled(t *testing.T) {
 	root := t.TempDir()
 	deckDir := filepath.Join(root, "mydeck")
@@ -110,6 +120,8 @@ func TestQueueContainsAllCardsShuffled(t *testing.T) {
 	}
 }
 
+// TestQueueSkipsNonCardFiles ensures that BuildQueue ignores Markdown
+// files that are not valid cards (e.g. missing frontmatter or ID).
 func TestQueueSkipsNonCardFiles(t *testing.T) {
 	root := t.TempDir()
 	deckDir := filepath.Join(root, "mydeck")

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,3 +1,6 @@
+// Package store persists review logs and card state for SRS decks.
+// It writes JSONL review entries and performs atomic rewrites of
+// Markdown card files so that crashes never leave data partially updated.
 package store
 
 import (
@@ -12,23 +15,29 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/fsrs"
 )
 
+// LogEntry is a single review event recorded as one JSON line.
 type LogEntry struct {
-	Schema     int            `json:"schema"`
-	TS         time.Time      `json:"ts"`
-	CardID     string         `json:"card_id"`
-	ClozeGroup *int           `json:"cloze_group,omitempty"`
-	Rating     int            `json:"rating"`
+	Schema int       `json:"schema"`
+	TS     time.Time `json:"ts"`
+	CardID string    `json:"card_id"`
+	// ClozeGroup is reserved for future cloze-deletion grouping; currently unused.
+	ClozeGroup *int `json:"cloze_group,omitempty"`
+	Rating int `json:"rating"`
+	// DurationMs is reserved for future review-duration tracking; currently unused.
 	DurationMs int64          `json:"duration_ms"`
 	Prev       fsrs.CardState `json:"prev"`
 	Next       fsrs.CardState `json:"next"`
 }
 
+// Store manages the on-disk state for one deck.
 type Store struct {
 	stateDir string
 	deckSlug string
 	logPath  string
 }
 
+// NewStore creates a Store that persists data under stateDir for deckSlug.
+// Review logs are written to stateDir/deckSlug.jsonl.
 func NewStore(stateDir, deckSlug string) *Store {
 	return &Store{
 		stateDir: stateDir,
@@ -37,6 +46,8 @@ func NewStore(stateDir, deckSlug string) *Store {
 	}
 }
 
+// AppendLog marshals entry as JSON and appends it to the review log
+// file, creating the state directory and log file if necessary.
 func (s *Store) AppendLog(entry LogEntry) error {
 	if err := os.MkdirAll(s.stateDir, 0o755); err != nil {
 		return err
@@ -59,6 +70,9 @@ func (s *Store) AppendLog(entry LogEntry) error {
 	return f.Sync()
 }
 
+// AtomicWriteFile writes data to path by creating a temporary file in the
+// same directory, syncing it, and renaming it over path. This guarantees
+// that path never contains a partially written file.
 func AtomicWriteFile(path string, data []byte) error {
 	dir := filepath.Dir(path)
 	tmp, err := os.CreateTemp(dir, "*.tmp")
@@ -88,10 +102,13 @@ func AtomicWriteFile(path string, data []byte) error {
 	return nil
 }
 
+// RewriteCard serializes c and atomically overwrites cardPath.
 func (s *Store) RewriteCard(cardPath string, c *card.Card) error {
 	return AtomicWriteFile(cardPath, c.Serialize())
 }
 
+// Persist records a review log entry and updates the on-disk card file.
+// Both operations must succeed; the log is written before the card is rewritten.
 func (s *Store) Persist(entry LogEntry, cardPath string, c *card.Card) error {
 	if err := s.AppendLog(entry); err != nil {
 		return fmt.Errorf("store: persist log: %w", err)
@@ -102,6 +119,8 @@ func (s *Store) Persist(entry LogEntry, cardPath string, c *card.Card) error {
 	return nil
 }
 
+// EnsureID assigns a UUID v7 to c if it does not already have an ID.
+// It returns true when an ID was assigned and false if the card already had one.
 func EnsureID(c *card.Card) bool {
 	if c.ID != "" {
 		return false
@@ -114,6 +133,11 @@ func EnsureID(c *card.Card) bool {
 	return true
 }
 
+// StateDir returns the directory where review logs are stored.
 func (s *Store) StateDir() string { return s.stateDir }
+
+// DeckSlug returns the identifier used for this deck's log file name.
 func (s *Store) DeckSlug() string { return s.deckSlug }
-func (s *Store) LogPath() string  { return s.logPath }
+
+// LogPath returns the full path to the JSONL review log file.
+func (s *Store) LogPath() string { return s.logPath }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,3 +1,6 @@
+// Package store_test contains integration tests for the store package.
+// Tests exercise the public API (AppendLog, Persist, RewriteCard, EnsureID)
+// through real file I/O and round-trip validation.
 package store_test
 
 import (
@@ -13,6 +16,8 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/store"
 )
 
+// TestAppendLogWritesOneJSONLinePerCall checks that a single AppendLog call
+// produces exactly one valid JSON line with the expected fields.
 func TestAppendLogWritesOneJSONLinePerCall(t *testing.T) {
 	dir := t.TempDir()
 	s := store.NewStore(dir, "mydeck")
@@ -73,6 +78,8 @@ func TestAppendLogWritesOneJSONLinePerCall(t *testing.T) {
 	}
 }
 
+// TestAppendLogMultipleEntries verifies that consecutive AppendLog calls
+// append multiple independent JSON lines to the log file.
 func TestAppendLogMultipleEntries(t *testing.T) {
 	dir := t.TempDir()
 	s := store.NewStore(dir, "mydeck")
@@ -112,6 +119,8 @@ func TestAppendLogMultipleEntries(t *testing.T) {
 	}
 }
 
+// TestAppendLogIncludesClozeGroupWhenSet confirms that the ClozeGroup
+// field is marshaled when non-nil and omitted when nil.
 func TestAppendLogIncludesClozeGroupWhenSet(t *testing.T) {
 	dir := t.TempDir()
 	s := store.NewStore(dir, "mydeck")
@@ -146,6 +155,8 @@ func TestAppendLogIncludesClozeGroupWhenSet(t *testing.T) {
 	}
 }
 
+// TestRewriteCardAtomicNoTmpArtifact checks that RewriteCard leaves no
+// temporary files behind and correctly updates card frontmatter fields.
 func TestRewriteCardAtomicNoTmpArtifact(t *testing.T) {
 	cardDir := t.TempDir()
 	cardPath := filepath.Join(cardDir, "test.md")
@@ -189,6 +200,8 @@ func TestRewriteCardAtomicNoTmpArtifact(t *testing.T) {
 	}
 }
 
+// TestPersistWritesLogBeforeFrontmatter verifies that Persist writes the
+// review log entry and updates the card file with the new FSRS state.
 func TestPersistWritesLogBeforeFrontmatter(t *testing.T) {
 	cardDir := t.TempDir()
 	cardPath := filepath.Join(cardDir, "test.md")
@@ -240,6 +253,8 @@ func TestPersistWritesLogBeforeFrontmatter(t *testing.T) {
 	}
 }
 
+// TestEnsureIDAssignsUUIDv7WhenCardLacksID confirms that EnsureID generates
+// a UUID v7 and returns true when the card has no ID.
 func TestEnsureIDAssignsUUIDv7WhenCardLacksID(t *testing.T) {
 	c := &card.Card{
 		Meta: card.Meta{
@@ -262,6 +277,8 @@ func TestEnsureIDAssignsUUIDv7WhenCardLacksID(t *testing.T) {
 	}
 }
 
+// TestEnsureIDNoOpWhenCardHasID ensures that EnsureID is a no-op and
+// returns false when the card already has an ID.
 func TestEnsureIDNoOpWhenCardHasID(t *testing.T) {
 	c := &card.Card{
 		Meta: card.Meta{


### PR DESCRIPTION
## Summary

Add Go doc comments to `internal/deck`, `internal/store`, and their test files.

- Package-level comments describe the purpose of each package
- All exported types (`LogEntry`, `Store`) and functions (`Discover`, `BuildQueue`, `NewStore`, `AppendLog`, `AtomicWriteFile`, `RewriteCard`, `Persist`, `EnsureID`, `StateDir`, `DeckSlug`, `LogPath`) are documented
- Unimplemented fields (`ClozeGroup`, `DurationMs`) are documented as reserved for future use
- Test file package comments and per-test function comments added

## Verification

- `go doc ./internal/deck` and `go doc ./internal/store` show useful package comments
- `go vet ./internal/deck ./internal/store` passes
- `go test ./internal/deck ./internal/store` passes

Closes #31