### PR TITLE
docs(internal/tui): document review package and tests

### DIFF
--- a/internal/tui/review.go
+++ b/internal/tui/review.go
@@ -1,3 +1,13 @@
+// Package tui implements the Bubble Tea review interface for spaced-repetition
+// cards. A review session follows a three-state lifecycle:
+//
+//   1. Front — the question side is displayed.
+//   2. Back — pressing Space or Enter reveals the answer and shows interval
+//      previews (again, hard, good, easy) computed by the scheduler.
+//   3. Rate — pressing a rating key (1–4) applies the score via RateFunc,
+//      advances to the next card, and returns to the front state.
+//
+// When every card has been rated the session ends and View signals completion.
 package tui
 
 import (
@@ -10,8 +20,13 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/fsrs"
 )
 
+// RateFunc applies a user rating to a card and returns the resulting state,
+// interval previews for all possible ratings, and any error.
 type RateFunc func(c *card.Card, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, error)
 
+// ReviewModel is a Bubble Tea model that drives a flash-card review session.
+// It manages a deck of cards, tracks which side is visible, and coordinates
+// with a RateFunc to schedule cards after each rating.
 type ReviewModel struct {
 	cards       []*card.Card
 	index       int
@@ -22,6 +37,9 @@ type ReviewModel struct {
 	done        bool
 }
 
+// NewReviewModel creates a ReviewModel for the given cards. The rateFunc is
+// invoked each time the user presses a rating key (1–4) while the back side
+// is visible.
 func NewReviewModel(cards []*card.Card, rateFunc RateFunc) ReviewModel {
 	r, _ := glamour.NewTermRenderer(glamour.WithStandardStyle("dark"))
 	return ReviewModel{
@@ -31,18 +49,28 @@ func NewReviewModel(cards []*card.Card, rateFunc RateFunc) ReviewModel {
 	}
 }
 
+// ShowingBack reports whether the answer side of the current card is visible.
 func (m ReviewModel) ShowingBack() bool {
 	return m.showingBack
 }
 
+// CurrentIndex returns the position of the card currently being reviewed.
 func (m ReviewModel) CurrentIndex() int {
 	return m.index
 }
 
+// Init implements tea.Model.
 func (m ReviewModel) Init() tea.Cmd {
 	return nil
 }
 
+// Update implements tea.Model. It handles the review lifecycle:
+//
+//   • Space / Enter — flip the current card to its back side and compute
+//     interval previews via the fsrs scheduler.
+//   • 1–4 — rate the card (only valid while the back is showing), advance
+//     to the next card, and clear previews.
+//   • q — emit tea.Quit to exit the application.
 func (m ReviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.done {
 		return m, nil
@@ -85,6 +113,9 @@ func (m ReviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// View implements tea.Model. It renders the front or back of the current
+// card (markdown formatted via glamour) and, when the back is showing,
+// appends the interval previews returned by the scheduler.
 func (m ReviewModel) View() string {
 	if len(m.cards) == 0 {
 		return "No cards in this deck.\nPress q to quit."
@@ -104,6 +135,8 @@ func (m ReviewModel) View() string {
 	return rendered
 }
 
+// cardStateFromCard converts a card.Card into the fsrs.CardState used by the
+// scheduler.
 func cardStateFromCard(c *card.Card) fsrs.CardState {
 	return fsrs.CardState{
 		State:      fsrs.NormalizeState(c.State),
@@ -115,6 +148,8 @@ func cardStateFromCard(c *card.Card) fsrs.CardState {
 	}
 }
 
+// formatPreviews renders a list of interval previews as rating labels with
+// human-readable intervals (e.g. "1 Again (1m)").
 func formatPreviews(previews []fsrs.IntervalPreview) string {
 	labels := map[int]string{1: "Again", 2: "Hard", 3: "Good", 4: "Easy"}
 	var s string
@@ -126,6 +161,8 @@ func formatPreviews(previews []fsrs.IntervalPreview) string {
 	return s
 }
 
+// formatDuration converts a time.Duration into a compact string:
+// "< 1m" for sub-minute, "%dm" for minutes, "%dh" for hours, and "%dd" for days.
 func formatDuration(d time.Duration) string {
 	if d < time.Minute {
 		return "< 1m"

--- a/internal/tui/review_test.go
+++ b/internal/tui/review_test.go
@@ -1,3 +1,8 @@
+// Package tui_test contains integration tests for the review TUI.
+//
+// Tests exercise the ReviewModel through its public Update and View methods
+// rather than internal state, matching the project’s behavior-first testing
+// philosophy.
 package tui_test
 
 import (
@@ -11,10 +16,14 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/tui"
 )
 
+// asReview asserts that a tea.Model is a tui.ReviewModel and returns it.
+// It is used by tests that need ReviewModel-specific getters after an Update.
 func asReview(m tea.Model) tui.ReviewModel {
 	return m.(tui.ReviewModel)
 }
 
+// TestReviewFlipOnSpace verifies that pressing Space reveals the back of the
+// current card.
 func TestReviewFlipOnSpace(t *testing.T) {
 	cards := []*card.Card{
 		{Meta: card.Meta{ID: "1", Type: card.Basic}, Front: "Q", Back: "A"},
@@ -29,6 +38,7 @@ func TestReviewFlipOnSpace(t *testing.T) {
 	}
 }
 
+// TestReviewFlipOnEnter verifies that pressing Enter also reveals the back.
 func TestReviewFlipOnEnter(t *testing.T) {
 	cards := []*card.Card{
 		{Meta: card.Meta{ID: "1", Type: card.Basic}, Front: "Q", Back: "A"},
@@ -40,6 +50,7 @@ func TestReviewFlipOnEnter(t *testing.T) {
 	}
 }
 
+// TestReviewQuitOnQ verifies that pressing 'q' returns a tea.Quit command.
 func TestReviewQuitOnQ(t *testing.T) {
 	cards := []*card.Card{
 		{Meta: card.Meta{ID: "1", Type: card.Basic}, Front: "Q", Back: "A"},
@@ -51,6 +62,8 @@ func TestReviewQuitOnQ(t *testing.T) {
 	}
 }
 
+// fakeRateFunc is a stub RateFunc that returns fixed interval previews for
+// every rating, making tests deterministic and fast.
 func fakeRateFunc(c *card.Card, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, error) {
 	next := fsrs.CardState{State: fsrs.StateLearning, Stability: 1.5}
 	previews := []fsrs.IntervalPreview{
@@ -62,6 +75,8 @@ func fakeRateFunc(c *card.Card, rating int, now time.Time) (fsrs.CardState, []fs
 	return next, previews, nil
 }
 
+// TestRatingKeyAdvancesCard checks that rating a flipped card moves the
+// session to the next card and resets the view to the front side.
 func TestRatingKeyAdvancesCard(t *testing.T) {
 	cards := []*card.Card{
 		{Meta: card.Meta{ID: "1", Type: card.Basic}, Front: "Q1", Back: "A1"},
@@ -81,6 +96,8 @@ func TestRatingKeyAdvancesCard(t *testing.T) {
 	}
 }
 
+// TestRatingKeyShowsIntervalPreviewsOnBack confirms that the rendered view
+// includes preview labels (Again, Hard, etc.) once the card is flipped.
 func TestRatingKeyShowsIntervalPreviewsOnBack(t *testing.T) {
 	cards := []*card.Card{
 		{Meta: card.Meta{ID: "1", Type: card.Basic}, Front: "Q", Back: "A"},
@@ -95,6 +112,8 @@ func TestRatingKeyShowsIntervalPreviewsOnBack(t *testing.T) {
 	}
 }
 
+// TestAllFourRatingKeysAccepted validates that every rating key (1–4) can be
+// used to advance through a multi-card session without error.
 func TestAllFourRatingKeysAccepted(t *testing.T) {
 	cards := []*card.Card{
 		{Meta: card.Meta{ID: "1", Type: card.Basic}, Front: "Q1", Back: "A1"},


### PR DESCRIPTION
Add Go doc comments to `internal/tui` and its test file covering the review state machine lifecycle, `ReviewModel`, `RateFunc`, and test helpers.

Closes #32