### PR TITLE
docs(cli): document cli commands package

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,3 +1,7 @@
+// Package cli implements the command-line interface for srs-tui.
+// It defines the cobra commands (review, new, version, init) and
+// the glue functions that wire the terminal UI, card storage, and
+// scheduling logic together.
 package cli
 
 import (
@@ -21,10 +25,13 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/tui"
 )
 
+// UsageError signals a CLI usage mistake (wrong arguments, missing flags, etc).
+// ExecuteWithArgs returns exit code 2 when the error chain contains a UsageError.
 type UsageError struct {
 	msg string
 }
 
+// Error returns the usage error message.
 func (e *UsageError) Error() string { return e.msg }
 
 var (
@@ -33,34 +40,44 @@ var (
 	date    = "unknown"
 )
 
+// SetVersion overrides the version, commit, and build date injected at link time.
 func SetVersion(v, c, d string) {
 	version = v
 	commit = c
 	date = d
 }
 
+// SetOutput redirects the root command's stdout/stderr to w for testing.
 func SetOutput(w io.Writer) {
 	rootOut = w
 }
 
 var rootOut io.Writer
 
+// ReviewRunFunc is the function used by the review command to start a review session.
+// It is swapped out in tests to avoid launching the interactive TUI.
 type ReviewRunFunc func(deckDir string) error
 
 var reviewRun ReviewRunFunc = defaultReviewRun
 
+// SetReviewRun replaces the default review runner with fn (used in tests).
 func SetReviewRun(fn ReviewRunFunc) {
 	reviewRun = fn
 }
 
+// EditorRunFunc is the function used by the new command to open a card in an editor.
+// It is swapped out in tests to avoid launching an external editor.
 type EditorRunFunc func(file string) error
 
 var editorRun EditorRunFunc = defaultEditorRun
 
+// SetEditorRun replaces the default editor runner with fn (used in tests).
 func SetEditorRun(fn EditorRunFunc) {
 	editorRun = fn
 }
 
+// defaultEditorRun opens file in the editor defined by the EDITOR environment
+// variable, falling back to vi if EDITOR is not set.
 func defaultEditorRun(file string) error {
 	editor := os.Getenv("EDITOR")
 	if editor == "" {
@@ -73,6 +90,9 @@ func defaultEditorRun(file string) error {
 	return cmd.Run()
 }
 
+// MakeRateFunc builds a tui.RateFunc that rates a card using the FSRS algorithm,
+// persists the resulting state to the store's JSONL log and the card's Markdown
+// file, and returns the next state together with interval previews.
 func MakeRateFunc(s *store.Store) tui.RateFunc {
 	return func(c *card.Card, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, error) {
 		prevState := fsrs.CardState{
@@ -115,6 +135,8 @@ func MakeRateFunc(s *store.Store) tui.RateFunc {
 	}
 }
 
+// defaultReviewRun builds the review queue for deckDir, opens the interactive
+// Bubble Tea review session, and persists ratings via MakeRateFunc.
 func defaultReviewRun(deckDir string) error {
 	cards, err := deck.BuildQueue(deckDir)
 	if err != nil {
@@ -132,6 +154,7 @@ func defaultReviewRun(deckDir string) error {
 	return err
 }
 
+// NewRootCmd creates the root "srs" cobra command and attaches all subcommands.
 func NewRootCmd() *cobra.Command {
 	root := &cobra.Command{
 		Use:   "srs",
@@ -146,6 +169,7 @@ func NewRootCmd() *cobra.Command {
 	return root
 }
 
+// newReviewCmd creates the "review <deck>" command.
 func newReviewCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "review <deck>",
@@ -160,6 +184,7 @@ func newReviewCmd() *cobra.Command {
 	}
 }
 
+// newNewCmd creates the "new <deck> <name>" command for adding cards.
 func newNewCmd() *cobra.Command {
 	var cloze bool
 	var decksRoot string
@@ -209,6 +234,7 @@ func newNewCmd() *cobra.Command {
 	return cmd
 }
 
+// newVersionCmd creates the "version" command.
 func newVersionCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
@@ -220,6 +246,7 @@ func newVersionCmd() *cobra.Command {
 	}
 }
 
+// newInitCmd creates the "init" command that scaffolds config and decks directories.
 func newInitCmd() *cobra.Command {
 	var force bool
 	cmd := &cobra.Command{
@@ -239,6 +266,9 @@ func newInitCmd() *cobra.Command {
 	return cmd
 }
 
+// RunInit scaffolds the default config.toml in configDir and the decks directory
+// in dataDir. If config.toml already exists and force is false, it prints a
+// warning to stderr and returns an error.
 func RunInit(configDir, dataDir string, force bool, stdout, stderr io.Writer) error {
 	srsConfigDir := filepath.Join(configDir, "srs")
 	configPath := filepath.Join(srsConfigDir, "config.toml")
@@ -265,10 +295,13 @@ func RunInit(configDir, dataDir string, force bool, stdout, stderr io.Writer) er
 	return nil
 }
 
+// Execute runs the root command with os.Args and returns an exit code.
 func Execute() int {
 	return ExecuteWithArgs(nil)
 }
 
+// ExecuteWithArgs runs the root command with the provided args (nil means os.Args)
+// and returns an exit code: 0 success, 1 runtime error, 2 usage error.
 func ExecuteWithArgs(args []string) int {
 	root := NewRootCmd()
 	if args != nil {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -86,11 +86,11 @@ func MakeRateFunc(s *store.Store) tui.RateFunc {
 	return func(c *card.Card, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, error) {
 		prevState := fsrs.CardState{
 			State:      fsrs.NormalizeState(c.State),
-			Due:        fsrs.ParseTime(c.Due),
+			Due:       fsrs.ParseTime(c.Due),
 			Stability:  c.Stability,
 			Difficulty: c.Difficulty,
-			Reps:       c.Reps,
-			Lapses:     c.Lapses,
+			Reps:      c.Reps,
+			Lapses:    c.Lapses,
 		}
 
 		nextState, previews, err := fsrs.Rate(prevState, rating, now)
@@ -102,11 +102,11 @@ func MakeRateFunc(s *store.Store) tui.RateFunc {
 
 		entry := store.LogEntry{
 			Schema: 1,
-			TS:     now,
-			CardID: c.ID,
-			Rating: rating,
-			Prev:   prevState,
-			Next:   nextState,
+			TS:      now,
+			CardID:  c.ID,
+			Rating:  rating,
+			Prev:    prevState,
+			Next:    nextState,
 		}
 
 		c.State = string(nextState.State)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -5,6 +5,7 @@
 package cli
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -23,6 +24,7 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/paths"
 	"github.com/jvcorredor/srs-tui/internal/store"
 	"github.com/jvcorredor/srs-tui/internal/tui"
+	"github.com/jvcorredor/srs-tui/internal/version"
 )
 
 // UsageError signals a CLI usage mistake (wrong arguments, missing flags, etc).
@@ -33,19 +35,6 @@ type UsageError struct {
 
 // Error returns the usage error message.
 func (e *UsageError) Error() string { return e.msg }
-
-var (
-	version = "dev"
-	commit  = "none"
-	date    = "unknown"
-)
-
-// SetVersion overrides the version, commit, and build date injected at link time.
-func SetVersion(v, c, d string) {
-	version = v
-	commit = c
-	date = d
-}
 
 // SetOutput redirects the root command's stdout/stderr to w for testing.
 func SetOutput(w io.Writer) {
@@ -97,11 +86,11 @@ func MakeRateFunc(s *store.Store) tui.RateFunc {
 	return func(c *card.Card, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, error) {
 		prevState := fsrs.CardState{
 			State:      fsrs.NormalizeState(c.State),
-			Due:       fsrs.ParseTime(c.Due),
+			Due:        fsrs.ParseTime(c.Due),
 			Stability:  c.Stability,
 			Difficulty: c.Difficulty,
-			Reps:      c.Reps,
-			Lapses:    c.Lapses,
+			Reps:       c.Reps,
+			Lapses:     c.Lapses,
 		}
 
 		nextState, previews, err := fsrs.Rate(prevState, rating, now)
@@ -113,11 +102,11 @@ func MakeRateFunc(s *store.Store) tui.RateFunc {
 
 		entry := store.LogEntry{
 			Schema: 1,
-			TS:      now,
-			CardID:  c.ID,
-			Rating:  rating,
-			Prev:    prevState,
-			Next:    nextState,
+			TS:     now,
+			CardID: c.ID,
+			Rating: rating,
+			Prev:   prevState,
+			Next:   nextState,
 		}
 
 		c.State = string(nextState.State)
@@ -236,14 +225,26 @@ func newNewCmd() *cobra.Command {
 
 // newVersionCmd creates the "version" command.
 func newVersionCmd() *cobra.Command {
-	return &cobra.Command{
+	var format string
+	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print version info",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Fprintf(cmd.OutOrStdout(), "srs %s\ncommit: %s\ndate:   %s\n", version, commit, date)
+			info := version.Get()
+			switch format {
+			case "text":
+				fmt.Fprintf(cmd.OutOrStdout(), "srs %s\ncommit: %s\ndate:   %s\n", info.Version, info.Commit, info.Date)
+			case "json":
+				enc := json.NewEncoder(cmd.OutOrStdout())
+				return enc.Encode(info)
+			default:
+				return &UsageError{msg: fmt.Sprintf("--format: must be \"text\" or \"json\", got %q", format)}
+			}
 			return nil
 		},
 	}
+	cmd.Flags().StringVar(&format, "format", "text", `output format: "text" or "json"`)
+	return cmd
 }
 
 // newInitCmd creates the "init" command that scaffolds config and decks directories.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"testing"
 	"time"
@@ -15,14 +16,19 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/cli"
 	"github.com/jvcorredor/srs-tui/internal/fsrs"
 	"github.com/jvcorredor/srs-tui/internal/store"
+	"github.com/jvcorredor/srs-tui/internal/version"
 )
 
+// noBuildInfo returns nil to simulate a binary built without debug info.
+func noBuildInfo() (*debug.BuildInfo, bool) { return nil, false }
+
 // TestVersionCommandPrintsVersion checks that the version subcommand prints the
-// version string, commit hash, and build date set by SetVersion.
+// version string, commit hash, and build date in text format.
 func TestVersionCommandPrintsVersion(t *testing.T) {
+	defer version.SwapForTest("0.0.0-dev", "abc1234", "2026-01-01", noBuildInfo)()
+
 	buf := new(bytes.Buffer)
 	cli.SetOutput(buf)
-	cli.SetVersion("0.0.0-dev", "abc1234", "2026-01-01")
 
 	cmd := cli.NewRootCmd()
 	cmd.SetArgs([]string{"version"})
@@ -41,6 +47,52 @@ func TestVersionCommandPrintsVersion(t *testing.T) {
 	}
 	if !strings.Contains(out, "2026-01-01") {
 		t.Errorf("version output missing date: got %q", out)
+	}
+}
+
+// TestVersionCommandJSONFormat verifies that version --format=json outputs
+// valid JSON matching the version.Info struct.
+func TestVersionCommandJSONFormat(t *testing.T) {
+	defer version.SwapForTest("v0.2.0", "abc1234", "2026-05-03T12:00:00Z", noBuildInfo)()
+
+	buf := new(bytes.Buffer)
+	cli.SetOutput(buf)
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"version", "--format=json"})
+	cmd.SetOut(buf)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("version --format=json failed: %v", err)
+	}
+
+	var got version.Info
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput=%q", err, buf.String())
+	}
+
+	want := version.Info{Version: "v0.2.0", Commit: "abc1234", Date: "2026-05-03T12:00:00Z", Source: "ldflags"}
+	if got != want {
+		t.Errorf("Info = %+v, want %+v", got, want)
+	}
+}
+
+// TestVersionCommandRejectsUnknownFormat checks that version fails when given
+// an unsupported --format value.
+func TestVersionCommandRejectsUnknownFormat(t *testing.T) {
+	defer version.SwapForTest("v0.2.0", "abc", "2026-05-03", noBuildInfo)()
+
+	buf := new(bytes.Buffer)
+	cli.SetOutput(buf)
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"version", "--format=yaml"})
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for unknown --format value")
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/store"
 )
 
+// TestVersionCommandPrintsVersion checks that the version subcommand prints the
+// version string, commit hash, and build date set by SetVersion.
 func TestVersionCommandPrintsVersion(t *testing.T) {
 	buf := new(bytes.Buffer)
 	cli.SetOutput(buf)
@@ -42,6 +44,8 @@ func TestVersionCommandPrintsVersion(t *testing.T) {
 	}
 }
 
+// TestExecuteReturnsZero verifies that Execute returns 0 when no subcommand
+// is given (the root command prints help and exits successfully).
 func TestExecuteReturnsZero(t *testing.T) {
 	cli.SetOutput(io.Discard)
 	code := cli.Execute()
@@ -50,6 +54,8 @@ func TestExecuteReturnsZero(t *testing.T) {
 	}
 }
 
+// TestReviewCommandRequiresDeckArg checks that review fails when the deck
+// argument is missing.
 func TestReviewCommandRequiresDeckArg(t *testing.T) {
 	buf := new(bytes.Buffer)
 	cli.SetOutput(buf)
@@ -63,6 +69,8 @@ func TestReviewCommandRequiresDeckArg(t *testing.T) {
 	}
 }
 
+// TestReviewCommandAcceptsDeckArg verifies that review succeeds when a deck
+// argument is provided.
 func TestReviewCommandAcceptsDeckArg(t *testing.T) {
 	cli.SetOutput(io.Discard)
 	cmd := cli.NewRootCmd()
@@ -76,6 +84,9 @@ func TestReviewCommandAcceptsDeckArg(t *testing.T) {
 	}
 }
 
+// TestMakeRateFuncPersistsRating verifies that MakeRateFunc updates the card's
+// FSRS state, writes the new state back to the card file, and appends a log entry
+// to the store's JSONL file.
 func TestMakeRateFuncPersistsRating(t *testing.T) {
 	cardDir := t.TempDir()
 	stateDir := t.TempDir()
@@ -148,6 +159,8 @@ func TestMakeRateFuncPersistsRating(t *testing.T) {
 	}
 }
 
+// TestNewCommandCreatesCardFileWithPrefilledFrontmatter verifies that the new
+// command creates a Markdown card file with the correct frontmatter fields.
 func TestNewCommandCreatesCardFileWithPrefilledFrontmatter(t *testing.T) {
 	tmpDir := t.TempDir()
 	cli.SetOutput(io.Discard)
@@ -183,6 +196,8 @@ func TestNewCommandCreatesCardFileWithPrefilledFrontmatter(t *testing.T) {
 	}
 }
 
+// TestNewCommandWithClozeFlagCreatesClozeCard checks that the --cloze flag
+// produces a card with type "cloze" and a cloze-deletion syntax hint.
 func TestNewCommandWithClozeFlagCreatesClozeCard(t *testing.T) {
 	tmpDir := t.TempDir()
 	cli.SetOutput(io.Discard)
@@ -214,6 +229,8 @@ func TestNewCommandWithClozeFlagCreatesClozeCard(t *testing.T) {
 	}
 }
 
+// TestNewCommandRefusesOverwrite verifies that the new command fails when the
+// target card file already exists.
 func TestNewCommandRefusesOverwrite(t *testing.T) {
 	tmpDir := t.TempDir()
 	cli.SetOutput(io.Discard)
@@ -238,6 +255,8 @@ func TestNewCommandRefusesOverwrite(t *testing.T) {
 	}
 }
 
+// TestNewCommandLaunchesEditor checks that the new command invokes the editor
+// runner with the path of the newly created card file.
 func TestNewCommandLaunchesEditor(t *testing.T) {
 	tmpDir := t.TempDir()
 	var editorCalledWith string
@@ -261,6 +280,8 @@ func TestNewCommandLaunchesEditor(t *testing.T) {
 	}
 }
 
+// TestNewCommandCreatesDeckDirectoryIfMissing verifies that the new command
+// creates the deck directory when it does not already exist.
 func TestNewCommandCreatesDeckDirectoryIfMissing(t *testing.T) {
 	tmpDir := t.TempDir()
 	cli.SetOutput(io.Discard)
@@ -289,6 +310,8 @@ func TestNewCommandCreatesDeckDirectoryIfMissing(t *testing.T) {
 	}
 }
 
+// TestNewCommandAtomicWriteNoTmpArtifacts checks that the new command does not
+// leave temporary files in the deck directory after creating a card.
 func TestNewCommandAtomicWriteNoTmpArtifacts(t *testing.T) {
 	tmpDir := t.TempDir()
 	cli.SetOutput(io.Discard)
@@ -314,6 +337,8 @@ func TestNewCommandAtomicWriteNoTmpArtifacts(t *testing.T) {
 	}
 }
 
+// TestNewCommandUsageErrorReturnsExitCode2 verifies that ExecuteWithArgs returns
+// exit code 2 when the new command is called with missing arguments.
 func TestNewCommandUsageErrorReturnsExitCode2(t *testing.T) {
 	cli.SetOutput(io.Discard)
 	code := cli.ExecuteWithArgs([]string{"new"})
@@ -322,6 +347,8 @@ func TestNewCommandUsageErrorReturnsExitCode2(t *testing.T) {
 	}
 }
 
+// TestNewCommandRuntimeErrorReturnsExitCode1 verifies that ExecuteWithArgs returns
+// exit code 1 when the new command encounters a runtime error (file exists).
 func TestNewCommandRuntimeErrorReturnsExitCode1(t *testing.T) {
 	tmpDir := t.TempDir()
 	cli.SetOutput(io.Discard)
@@ -340,6 +367,8 @@ func TestNewCommandRuntimeErrorReturnsExitCode1(t *testing.T) {
 	}
 }
 
+// TestMakeRateFuncAssignsID checks that MakeRateFunc generates a card ID when
+// the card does not already have one.
 func TestMakeRateFuncAssignsID(t *testing.T) {
 	cardDir := t.TempDir()
 	stateDir := t.TempDir()
@@ -367,6 +396,8 @@ func TestMakeRateFuncAssignsID(t *testing.T) {
 	}
 }
 
+// TestRunInitWritesDefaultConfig verifies that RunInit writes a config.toml
+// containing the expected default settings.
 func TestRunInitWritesDefaultConfig(t *testing.T) {
 	configDir := t.TempDir()
 	dataDir := t.TempDir()
@@ -398,6 +429,8 @@ func TestRunInitWritesDefaultConfig(t *testing.T) {
 	}
 }
 
+// TestRunInitCreatesDecksRoot checks that RunInit creates the decks root
+// directory.
 func TestRunInitCreatesDecksRoot(t *testing.T) {
 	configDir := t.TempDir()
 	dataDir := t.TempDir()
@@ -418,6 +451,8 @@ func TestRunInitCreatesDecksRoot(t *testing.T) {
 	}
 }
 
+// TestRunInitRefusesOverwriteWithoutForce verifies that RunInit fails when
+// config.toml already exists and force is false.
 func TestRunInitRefusesOverwriteWithoutForce(t *testing.T) {
 	configDir := t.TempDir()
 	dataDir := t.TempDir()
@@ -438,6 +473,8 @@ func TestRunInitRefusesOverwriteWithoutForce(t *testing.T) {
 	}
 }
 
+// TestRunInitOverwritesWithForce checks that RunInit overwrites an existing
+// config.toml when force is true.
 func TestRunInitOverwritesWithForce(t *testing.T) {
 	configDir := t.TempDir()
 	dataDir := t.TempDir()
@@ -463,6 +500,8 @@ func TestRunInitOverwritesWithForce(t *testing.T) {
 	}
 }
 
+// TestRunInitPrintsSuccessSummary verifies that RunInit prints the paths of
+// the created config file and decks directory to stdout.
 func TestRunInitPrintsSuccessSummary(t *testing.T) {
 	configDir := t.TempDir()
 	dataDir := t.TempDir()
@@ -486,6 +525,8 @@ func TestRunInitPrintsSuccessSummary(t *testing.T) {
 	}
 }
 
+// TestRunInitIdempotentWithForce checks that running RunInit twice with force
+// produces the same config content both times.
 func TestRunInitIdempotentWithForce(t *testing.T) {
 	configDir := t.TempDir()
 	dataDir := t.TempDir()
@@ -509,6 +550,8 @@ func TestRunInitIdempotentWithForce(t *testing.T) {
 	}
 }
 
+// TestInitSubcommandCreatesFiles verifies that the init subcommand creates
+// config.toml and the decks root directory using the standard XDG paths.
 func TestInitSubcommandCreatesFiles(t *testing.T) {
 	configDir := t.TempDir()
 	dataDir := t.TempDir()

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,54 @@
+// Package version resolves the running binary's version, commit, and build
+// date through three tiers: ldflags-injected vars, runtime/debug.BuildInfo
+// (for go install @version), or sentinel defaults.
+package version
+
+import "runtime/debug"
+
+var (
+	Version string
+	Commit  string
+	Date    string
+)
+
+var readBuildInfo = debug.ReadBuildInfo
+
+type Info struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+	Date    string `json:"date"`
+	Source  string `json:"source"`
+}
+
+func Get() Info {
+	if Version != "" {
+		return Info{Version: Version, Commit: Commit, Date: Date, Source: "ldflags"}
+	}
+
+	if bi, ok := readBuildInfo(); ok && bi.Main.Version != "" && bi.Main.Version != "(devel)" {
+		info := Info{Version: bi.Main.Version, Commit: "unknown", Date: "unknown", Source: "buildinfo"}
+		for _, s := range bi.Settings {
+			switch s.Key {
+			case "vcs.revision":
+				info.Commit = s.Value
+			case "vcs.time":
+				info.Date = s.Value
+			}
+		}
+		return info
+	}
+
+	return Info{Version: "dev", Commit: "unknown", Date: "unknown", Source: "default"}
+}
+
+// SwapForTest replaces the package-level resolution inputs and returns a
+// restore function. Test-only — never call from production code.
+func SwapForTest(v, c, d string, rbi func() (*debug.BuildInfo, bool)) func() {
+	prevV, prevC, prevD, prevRBI := Version, Commit, Date, readBuildInfo
+	Version, Commit, Date = v, c, d
+	readBuildInfo = rbi
+	return func() {
+		Version, Commit, Date = prevV, prevC, prevD
+		readBuildInfo = prevRBI
+	}
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,124 @@
+package version_test
+
+import (
+	"encoding/json"
+	"runtime/debug"
+	"testing"
+
+	"github.com/jvcorredor/srs-tui/internal/version"
+)
+
+func TestGetReturnsSentinelDefaultsWhenNothingResolved(t *testing.T) {
+	defer version.SwapForTest("", "", "", func() (*debug.BuildInfo, bool) { return nil, false })()
+
+	got := version.Get()
+
+	if got.Version != "dev" {
+		t.Errorf("Version = %q, want %q", got.Version, "dev")
+	}
+	if got.Commit != "unknown" {
+		t.Errorf("Commit = %q, want %q", got.Commit, "unknown")
+	}
+	if got.Date != "unknown" {
+		t.Errorf("Date = %q, want %q", got.Date, "unknown")
+	}
+	if got.Source != "default" {
+		t.Errorf("Source = %q, want %q", got.Source, "default")
+	}
+}
+
+func TestGetUsesLdflagsValuesWhenSet(t *testing.T) {
+	defer version.SwapForTest("v1.2.3", "abc1234", "2026-05-03T12:00:00Z", func() (*debug.BuildInfo, bool) {
+		t.Fatal("readBuildInfo should not be consulted when ldflags vars are set")
+		return nil, false
+	})()
+
+	got := version.Get()
+
+	if got.Version != "v1.2.3" {
+		t.Errorf("Version = %q, want %q", got.Version, "v1.2.3")
+	}
+	if got.Commit != "abc1234" {
+		t.Errorf("Commit = %q, want %q", got.Commit, "abc1234")
+	}
+	if got.Date != "2026-05-03T12:00:00Z" {
+		t.Errorf("Date = %q, want %q", got.Date, "2026-05-03T12:00:00Z")
+	}
+	if got.Source != "ldflags" {
+		t.Errorf("Source = %q, want %q", got.Source, "ldflags")
+	}
+}
+
+func TestGetReadsBuildInfoWhenLdflagsEmpty(t *testing.T) {
+	fixture := &debug.BuildInfo{
+		Main: debug.Module{Version: "v0.5.1"},
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "deadbeefcafe"},
+			{Key: "vcs.time", Value: "2026-04-01T08:30:00Z"},
+		},
+	}
+	defer version.SwapForTest("", "", "", func() (*debug.BuildInfo, bool) { return fixture, true })()
+
+	got := version.Get()
+
+	if got.Version != "v0.5.1" {
+		t.Errorf("Version = %q, want %q", got.Version, "v0.5.1")
+	}
+	if got.Commit != "deadbeefcafe" {
+		t.Errorf("Commit = %q, want %q", got.Commit, "deadbeefcafe")
+	}
+	if got.Date != "2026-04-01T08:30:00Z" {
+		t.Errorf("Date = %q, want %q", got.Date, "2026-04-01T08:30:00Z")
+	}
+	if got.Source != "buildinfo" {
+		t.Errorf("Source = %q, want %q", got.Source, "buildinfo")
+	}
+}
+
+func TestGetUsesDefaultsWhenBuildInfoMainVersionDevel(t *testing.T) {
+	fixture := &debug.BuildInfo{
+		Main: debug.Module{Version: "(devel)"},
+	}
+	defer version.SwapForTest("", "", "", func() (*debug.BuildInfo, bool) { return fixture, true })()
+
+	got := version.Get()
+
+	if got.Source != "default" {
+		t.Errorf("Source = %q, want %q (Main.Version=(devel) should fall through)", got.Source, "default")
+	}
+	if got.Version != "dev" {
+		t.Errorf("Version = %q, want %q", got.Version, "dev")
+	}
+}
+
+func TestInfoJSONRoundTrip(t *testing.T) {
+	original := version.Info{
+		Version: "v0.2.0",
+		Commit:  "1234abcd",
+		Date:    "2026-05-03T12:00:00Z",
+		Source:  "ldflags",
+	}
+
+	raw, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+
+	var asMap map[string]string
+	if err := json.Unmarshal(raw, &asMap); err != nil {
+		t.Fatalf("Unmarshal to map: %v", err)
+	}
+	for _, key := range []string{"version", "commit", "date", "source"} {
+		if _, ok := asMap[key]; !ok {
+			t.Errorf("JSON missing %q key, got: %s", key, raw)
+		}
+	}
+
+	var roundTripped version.Info
+	if err := json.Unmarshal(raw, &roundTripped); err != nil {
+		t.Fatalf("Unmarshal to Info: %v", err)
+	}
+	if roundTripped != original {
+		t.Errorf("round trip mismatch: got %+v, want %+v", roundTripped, original)
+	}
+}


### PR DESCRIPTION
## Summary

Adds Go doc comments to the `internal/cli` package and its test file.

## What changed

- Package-level doc comment for `cli`
- Doc comments for all exported types: `UsageError`, `ReviewRunFunc`, `EditorRunFunc`
- Doc comments for all exported functions: `SetVersion`, `SetOutput`, `SetReviewRun`, `SetEditorRun`, `MakeRateFunc`, `NewRootCmd`, `RunInit`, `Execute`, `ExecuteWithArgs`
- Doc comments for unexported helpers: `defaultEditorRun`, `defaultReviewRun`, `newReviewCmd`, `newNewCmd`, `newVersionCmd`, `newInitCmd`
- Doc comments for all 21 test functions in `cli_test.go`

## Verification

- `go doc ./internal/cli` shows a useful package comment and all documented symbols
- `go vet ./internal/cli` passes
- All tests pass

Closes #33