### PR TITLE
fix(tui): allow q key to quit after session complete

### DIFF
--- a/internal/tui/review.go
+++ b/internal/tui/review.go
@@ -72,12 +72,14 @@ func (m ReviewModel) Init() tea.Cmd {
 //     to the next card, and clear previews.
 //   • q — emit tea.Quit to exit the application.
 func (m ReviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	if m.done {
-		return m, nil
-	}
-
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		if msg.String() == "q" {
+			return m, tea.Quit
+		}
+		if m.done {
+			return m, nil
+		}
 		switch msg.Type {
 		case tea.KeySpace, tea.KeyEnter:
 			if !m.showingBack {
@@ -91,8 +93,6 @@ func (m ReviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		switch msg.String() {
-		case "q":
-			return m, tea.Quit
 		case "1", "2", "3", "4":
 			if m.showingBack && m.rateFunc != nil && m.index < len(m.cards) {
 				rating := int(msg.String()[0] - '0')

--- a/internal/tui/review_test.go
+++ b/internal/tui/review_test.go
@@ -62,6 +62,29 @@ func TestReviewQuitOnQ(t *testing.T) {
 	}
 }
 
+// TestReviewQuitOnQWhenDone verifies that pressing 'q' quits even after the
+// session is complete (m.done == true).
+func TestReviewQuitOnQWhenDone(t *testing.T) {
+	cards := []*card.Card{
+		{Meta: card.Meta{ID: "1", Type: card.Basic}, Front: "Q", Back: "A"},
+	}
+	m := tui.NewReviewModel(cards, fakeRateFunc)
+	// Flip and rate the only card so the session ends.
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	m = asReview(updated)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m = asReview(updated)
+
+	if m.CurrentIndex() != 1 {
+		t.Fatalf("expected session to be done, index = %d", m.CurrentIndex())
+	}
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	if cmd == nil {
+		t.Error("q should trigger quit even when session is done")
+	}
+}
+
 // fakeRateFunc is a stub RateFunc that returns fixed interval previews for
 // every rating, making tests deterministic and fast.
 func fakeRateFunc(c *card.Card, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, error) {


### PR DESCRIPTION
## Summary

Fixes a bug where pressing `q` did nothing after the review session ended.

## Problem

In `ReviewModel.Update()`, the `m.done` early-return was placed before the `q` key handler, so once the last card was rated, pressing `q` was swallowed and the only escape was `Ctrl+C`.

## Fix

Move the `q` → `tea.Quit` check above the `m.done` guard so it works in all states.

## Changes

- `internal/tui/review.go`: reorder `q` handling before `m.done` early-return
- `internal/tui/review_test.go`: add `TestReviewQuitOnQWhenDone` regression test

## Verification

- `go test ./internal/tui/` — all 7 tests pass
- `go test ./...` — full suite passes

Closes: #42