### PR TITLE
docs: restore detailed Go doc comments lost in rebase

### DIFF
--- a/cmd/srs/main.go
+++ b/cmd/srs/main.go
@@ -1,4 +1,8 @@
-// Command srs is the terminal spaced-repetition application entry point.
+// srs is a terminal UI for spaced-repetition flashcards.
+//
+// It exposes sub-commands for reviewing decks, creating cards, and
+// managing configuration.  The real logic lives in internal/cli; this
+// file is the minimal entry point that delegates to it.
 package main
 
 import (

--- a/internal/card/card.go
+++ b/internal/card/card.go
@@ -1,4 +1,8 @@
-// Package card parses and serializes markdown flashcard files.
+// Package card implements the Markdown card file model used by srs-tui.
+//
+// A card is stored as a Markdown file with YAML frontmatter followed by
+// ## Front and ## Back sections. The frontmatter contains metadata such as
+// ID, type, creation time, and FSRS scheduling fields.
 package card
 
 import (
@@ -13,13 +17,17 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// Type describes the kind of card.
 type Type string
 
 const (
+	// Basic is a standard question/answer card.
 	Basic Type = "basic"
+	// Cloze is a fill-in-the-blank card.
 	Cloze Type = "cloze"
 )
 
+// Meta holds the YAML frontmatter for a card.
 type Meta struct {
 	Schema     int      `yaml:"schema"`
 	ID         string   `yaml:"id"`
@@ -34,6 +42,7 @@ type Meta struct {
 	Lapses     int      `yaml:"lapses,omitempty"`
 }
 
+// Card represents a spaced-repetition card backed by a Markdown file.
 type Card struct {
 	Meta
 	Front    string
@@ -44,6 +53,7 @@ type Card struct {
 var frontHeading = regexp.MustCompile(`(?m)^## Front\s*$`)
 var backHeading = regexp.MustCompile(`(?m)^## Back\s*$`)
 
+// NewCard creates a new card with a generated UUID v7 and the given type.
 func NewCard(cardType Type, now time.Time) *Card {
 	id, _ := uuid.NewV7()
 	return &Card{
@@ -57,6 +67,8 @@ func NewCard(cardType Type, now time.Time) *Card {
 	}
 }
 
+// ParseFile reads a Markdown card file and parses it into a Card.
+// The file path is recorded in the returned Card's FilePath field.
 func ParseFile(path string) (*Card, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -72,6 +84,8 @@ func ParseFile(path string) (*Card, error) {
 	return c, nil
 }
 
+// Parse converts raw Markdown bytes into a Card.
+// If the data has no frontmatter or no ID, it returns nil, nil.
 func Parse(data []byte) (*Card, error) {
 	fm, body, err := splitFrontmatter(data)
 	if err != nil {
@@ -91,6 +105,8 @@ func Parse(data []byte) (*Card, error) {
 	}, nil
 }
 
+// Serialize writes the card back to its Markdown representation,
+// including YAML frontmatter and Front/Back sections.
 func (c *Card) Serialize() []byte {
 	fmData, _ := yaml.Marshal(&c.Meta)
 	var b strings.Builder
@@ -110,6 +126,9 @@ func (c *Card) Serialize() []byte {
 	return []byte(b.String())
 }
 
+// SerializeNew returns a minimal Markdown template for a newly created card.
+// For cloze cards it includes a placeholder; for basic cards it provides
+// empty Front and Back headings.
 func (c *Card) SerializeNew() []byte {
 	fmData, _ := yaml.Marshal(&c.Meta)
 	var b strings.Builder
@@ -124,6 +143,8 @@ func (c *Card) SerializeNew() []byte {
 	return []byte(b.String())
 }
 
+// splitFrontmatter extracts the YAML frontmatter and the remaining body from data.
+// If there is no frontmatter, it returns nil, data, nil.
 func splitFrontmatter(data []byte) (*Meta, []byte, error) {
 	if !bytes.HasPrefix(data, []byte("---\n")) {
 		return nil, data, nil
@@ -142,6 +163,8 @@ func splitFrontmatter(data []byte) (*Meta, []byte, error) {
 	return &meta, body, nil
 }
 
+// splitBody extracts the front and back text from the Markdown body
+// by looking for ## Front and ## Back headings.
 func splitBody(body string) (front, back string) {
 	loc := frontHeading.FindStringIndex(body)
 	if loc != nil {

--- a/internal/card/card_test.go
+++ b/internal/card/card_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/card"
 )
 
+// TestParseFile exercises ParseFile against golden files and edge cases
+// (missing frontmatter, missing ID, malformed YAML).
 func TestParseFile(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -87,6 +89,8 @@ func TestParseFile(t *testing.T) {
 	}
 }
 
+// TestRoundTripFSRSFields verifies that FSRS scheduling fields survive a
+// Serialize → Parse round-trip without loss of precision.
 func TestRoundTripFSRSFields(t *testing.T) {
 	c := &card.Card{
 		Meta: card.Meta{
@@ -129,6 +133,8 @@ func TestRoundTripFSRSFields(t *testing.T) {
 	}
 }
 
+// TestRoundTripBasicCard checks that a basic card's ID, Type, Front, and Back
+// survive a Parse → Serialize → Parse round-trip.
 func TestRoundTripBasicCard(t *testing.T) {
 	original, err := os.ReadFile("testdata/basic.md")
 	if err != nil {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,4 +1,7 @@
-// Package cli implements the command-line interface and subcommands.
+// Package cli implements the command-line interface for srs-tui.
+// It defines the cobra commands (review, new, version, init) and
+// the glue functions that wire the terminal UI, card storage, and
+// scheduling logic together.
 package cli
 
 import (
@@ -24,34 +27,46 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/version"
 )
 
+// UsageError signals a CLI usage mistake (wrong arguments, missing flags, etc).
+// ExecuteWithArgs returns exit code 2 when the error chain contains a UsageError.
 type UsageError struct {
 	msg string
 }
 
+// Error returns the usage error message.
 func (e *UsageError) Error() string { return e.msg }
 
+// SetOutput redirects the root command's stdout/stderr to w for testing.
 func SetOutput(w io.Writer) {
 	rootOut = w
 }
 
 var rootOut io.Writer
 
+// ReviewRunFunc is the function used by the review command to start a review session.
+// It is swapped out in tests to avoid launching the interactive TUI.
 type ReviewRunFunc func(deckDir string) error
 
 var reviewRun ReviewRunFunc = defaultReviewRun
 
+// SetReviewRun replaces the default review runner with fn (used in tests).
 func SetReviewRun(fn ReviewRunFunc) {
 	reviewRun = fn
 }
 
+// EditorRunFunc is the function used by the new command to open a card in an editor.
+// It is swapped out in tests to avoid launching an external editor.
 type EditorRunFunc func(file string) error
 
 var editorRun EditorRunFunc = defaultEditorRun
 
+// SetEditorRun replaces the default editor runner with fn (used in tests).
 func SetEditorRun(fn EditorRunFunc) {
 	editorRun = fn
 }
 
+// defaultEditorRun opens file in the editor defined by the EDITOR environment
+// variable, falling back to vi if EDITOR is not set.
 func defaultEditorRun(file string) error {
 	editor := os.Getenv("EDITOR")
 	if editor == "" {
@@ -64,15 +79,18 @@ func defaultEditorRun(file string) error {
 	return cmd.Run()
 }
 
+// MakeRateFunc builds a tui.RateFunc that rates a card using the FSRS algorithm,
+// persists the resulting state to the store's JSONL log and the card's Markdown
+// file, and returns the next state together with interval previews.
 func MakeRateFunc(s *store.Store) tui.RateFunc {
 	return func(c *card.Card, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, error) {
 		prevState := fsrs.CardState{
 			State:      fsrs.NormalizeState(c.State),
-			Due:       fsrs.ParseTime(c.Due),
+			Due:        fsrs.ParseTime(c.Due),
 			Stability:  c.Stability,
 			Difficulty: c.Difficulty,
-			Reps:      c.Reps,
-			Lapses:    c.Lapses,
+			Reps:       c.Reps,
+			Lapses:     c.Lapses,
 		}
 
 		nextState, previews, err := fsrs.Rate(prevState, rating, now)
@@ -84,11 +102,11 @@ func MakeRateFunc(s *store.Store) tui.RateFunc {
 
 		entry := store.LogEntry{
 			Schema: 1,
-			TS:      now,
-			CardID:  c.ID,
-			Rating:  rating,
-			Prev:    prevState,
-			Next:    nextState,
+			TS:     now,
+			CardID: c.ID,
+			Rating: rating,
+			Prev:   prevState,
+			Next:   nextState,
 		}
 
 		c.State = string(nextState.State)
@@ -106,6 +124,8 @@ func MakeRateFunc(s *store.Store) tui.RateFunc {
 	}
 }
 
+// defaultReviewRun builds the review queue for deckDir, opens the interactive
+// Bubble Tea review session, and persists ratings via MakeRateFunc.
 func defaultReviewRun(deckDir string) error {
 	cards, err := deck.BuildQueue(deckDir)
 	if err != nil {
@@ -123,6 +143,7 @@ func defaultReviewRun(deckDir string) error {
 	return err
 }
 
+// NewRootCmd creates the root "srs" cobra command and attaches all subcommands.
 func NewRootCmd() *cobra.Command {
 	root := &cobra.Command{
 		Use:   "srs",
@@ -137,6 +158,7 @@ func NewRootCmd() *cobra.Command {
 	return root
 }
 
+// newReviewCmd creates the "review <deck>" command.
 func newReviewCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "review <deck>",
@@ -151,6 +173,7 @@ func newReviewCmd() *cobra.Command {
 	}
 }
 
+// newNewCmd creates the "new <deck> <name>" command for adding cards.
 func newNewCmd() *cobra.Command {
 	var cloze bool
 	var decksRoot string
@@ -200,6 +223,7 @@ func newNewCmd() *cobra.Command {
 	return cmd
 }
 
+// newVersionCmd creates the "version" command.
 func newVersionCmd() *cobra.Command {
 	var format string
 	cmd := &cobra.Command{
@@ -223,6 +247,7 @@ func newVersionCmd() *cobra.Command {
 	return cmd
 }
 
+// newInitCmd creates the "init" command that scaffolds config and decks directories.
 func newInitCmd() *cobra.Command {
 	var force bool
 	cmd := &cobra.Command{
@@ -242,6 +267,9 @@ func newInitCmd() *cobra.Command {
 	return cmd
 }
 
+// RunInit scaffolds the default config.toml in configDir and the decks directory
+// in dataDir. If config.toml already exists and force is false, it prints a
+// warning to stderr and returns an error.
 func RunInit(configDir, dataDir string, force bool, stdout, stderr io.Writer) error {
 	srsConfigDir := filepath.Join(configDir, "srs")
 	configPath := filepath.Join(srsConfigDir, "config.toml")
@@ -268,10 +296,13 @@ func RunInit(configDir, dataDir string, force bool, stdout, stderr io.Writer) er
 	return nil
 }
 
+// Execute runs the root command with os.Args and returns an exit code.
 func Execute() int {
 	return ExecuteWithArgs(nil)
 }
 
+// ExecuteWithArgs runs the root command with the provided args (nil means os.Args)
+// and returns an exit code: 0 success, 1 runtime error, 2 usage error.
 func ExecuteWithArgs(args []string) int {
 	root := NewRootCmd()
 	if args != nil {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -19,8 +19,11 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/version"
 )
 
+// noBuildInfo returns nil to simulate a binary built without debug info.
 func noBuildInfo() (*debug.BuildInfo, bool) { return nil, false }
 
+// TestVersionCommandPrintsVersion checks that the version subcommand prints the
+// version string, commit hash, and build date in text format.
 func TestVersionCommandPrintsVersion(t *testing.T) {
 	defer version.SwapForTest("0.0.0-dev", "abc1234", "2026-01-01", noBuildInfo)()
 
@@ -47,6 +50,8 @@ func TestVersionCommandPrintsVersion(t *testing.T) {
 	}
 }
 
+// TestVersionCommandJSONFormat verifies that version --format=json outputs
+// valid JSON matching the version.Info struct.
 func TestVersionCommandJSONFormat(t *testing.T) {
 	defer version.SwapForTest("v0.2.0", "abc1234", "2026-05-03T12:00:00Z", noBuildInfo)()
 
@@ -72,6 +77,8 @@ func TestVersionCommandJSONFormat(t *testing.T) {
 	}
 }
 
+// TestVersionCommandRejectsUnknownFormat checks that version fails when given
+// an unsupported --format value.
 func TestVersionCommandRejectsUnknownFormat(t *testing.T) {
 	defer version.SwapForTest("v0.2.0", "abc", "2026-05-03", noBuildInfo)()
 
@@ -89,6 +96,8 @@ func TestVersionCommandRejectsUnknownFormat(t *testing.T) {
 	}
 }
 
+// TestExecuteReturnsZero verifies that Execute returns 0 when no subcommand
+// is given (the root command prints help and exits successfully).
 func TestExecuteReturnsZero(t *testing.T) {
 	cli.SetOutput(io.Discard)
 	code := cli.Execute()
@@ -97,6 +106,8 @@ func TestExecuteReturnsZero(t *testing.T) {
 	}
 }
 
+// TestReviewCommandRequiresDeckArg checks that review fails when the deck
+// argument is missing.
 func TestReviewCommandRequiresDeckArg(t *testing.T) {
 	buf := new(bytes.Buffer)
 	cli.SetOutput(buf)
@@ -110,6 +121,8 @@ func TestReviewCommandRequiresDeckArg(t *testing.T) {
 	}
 }
 
+// TestReviewCommandAcceptsDeckArg verifies that review succeeds when a deck
+// argument is provided.
 func TestReviewCommandAcceptsDeckArg(t *testing.T) {
 	cli.SetOutput(io.Discard)
 	cmd := cli.NewRootCmd()
@@ -123,6 +136,9 @@ func TestReviewCommandAcceptsDeckArg(t *testing.T) {
 	}
 }
 
+// TestMakeRateFuncPersistsRating verifies that MakeRateFunc updates the card's
+// FSRS state, writes the new state back to the card file, and appends a log entry
+// to the store's JSONL file.
 func TestMakeRateFuncPersistsRating(t *testing.T) {
 	cardDir := t.TempDir()
 	stateDir := t.TempDir()
@@ -195,6 +211,8 @@ func TestMakeRateFuncPersistsRating(t *testing.T) {
 	}
 }
 
+// TestNewCommandCreatesCardFileWithPrefilledFrontmatter verifies that the new
+// command creates a Markdown card file with the correct frontmatter fields.
 func TestNewCommandCreatesCardFileWithPrefilledFrontmatter(t *testing.T) {
 	tmpDir := t.TempDir()
 	cli.SetOutput(io.Discard)
@@ -230,6 +248,8 @@ func TestNewCommandCreatesCardFileWithPrefilledFrontmatter(t *testing.T) {
 	}
 }
 
+// TestNewCommandWithClozeFlagCreatesClozeCard checks that the --cloze flag
+// produces a card with type "cloze" and a cloze-deletion syntax hint.
 func TestNewCommandWithClozeFlagCreatesClozeCard(t *testing.T) {
 	tmpDir := t.TempDir()
 	cli.SetOutput(io.Discard)
@@ -261,6 +281,8 @@ func TestNewCommandWithClozeFlagCreatesClozeCard(t *testing.T) {
 	}
 }
 
+// TestNewCommandRefusesOverwrite verifies that the new command fails when the
+// target card file already exists.
 func TestNewCommandRefusesOverwrite(t *testing.T) {
 	tmpDir := t.TempDir()
 	cli.SetOutput(io.Discard)
@@ -285,6 +307,8 @@ func TestNewCommandRefusesOverwrite(t *testing.T) {
 	}
 }
 
+// TestNewCommandLaunchesEditor checks that the new command invokes the editor
+// runner with the path of the newly created card file.
 func TestNewCommandLaunchesEditor(t *testing.T) {
 	tmpDir := t.TempDir()
 	var editorCalledWith string
@@ -308,6 +332,8 @@ func TestNewCommandLaunchesEditor(t *testing.T) {
 	}
 }
 
+// TestNewCommandCreatesDeckDirectoryIfMissing verifies that the new command
+// creates the deck directory when it does not already exist.
 func TestNewCommandCreatesDeckDirectoryIfMissing(t *testing.T) {
 	tmpDir := t.TempDir()
 	cli.SetOutput(io.Discard)
@@ -336,6 +362,8 @@ func TestNewCommandCreatesDeckDirectoryIfMissing(t *testing.T) {
 	}
 }
 
+// TestNewCommandAtomicWriteNoTmpArtifacts checks that the new command does not
+// leave temporary files in the deck directory after creating a card.
 func TestNewCommandAtomicWriteNoTmpArtifacts(t *testing.T) {
 	tmpDir := t.TempDir()
 	cli.SetOutput(io.Discard)
@@ -361,6 +389,8 @@ func TestNewCommandAtomicWriteNoTmpArtifacts(t *testing.T) {
 	}
 }
 
+// TestNewCommandUsageErrorReturnsExitCode2 verifies that ExecuteWithArgs returns
+// exit code 2 when the new command is called with missing arguments.
 func TestNewCommandUsageErrorReturnsExitCode2(t *testing.T) {
 	cli.SetOutput(io.Discard)
 	code := cli.ExecuteWithArgs([]string{"new"})
@@ -369,6 +399,8 @@ func TestNewCommandUsageErrorReturnsExitCode2(t *testing.T) {
 	}
 }
 
+// TestNewCommandRuntimeErrorReturnsExitCode1 verifies that ExecuteWithArgs returns
+// exit code 1 when the new command encounters a runtime error (file exists).
 func TestNewCommandRuntimeErrorReturnsExitCode1(t *testing.T) {
 	tmpDir := t.TempDir()
 	cli.SetOutput(io.Discard)
@@ -387,6 +419,8 @@ func TestNewCommandRuntimeErrorReturnsExitCode1(t *testing.T) {
 	}
 }
 
+// TestMakeRateFuncAssignsID checks that MakeRateFunc generates a card ID when
+// the card does not already have one.
 func TestMakeRateFuncAssignsID(t *testing.T) {
 	cardDir := t.TempDir()
 	stateDir := t.TempDir()
@@ -414,6 +448,8 @@ func TestMakeRateFuncAssignsID(t *testing.T) {
 	}
 }
 
+// TestRunInitWritesDefaultConfig verifies that RunInit writes a config.toml
+// containing the expected default settings.
 func TestRunInitWritesDefaultConfig(t *testing.T) {
 	configDir := t.TempDir()
 	dataDir := t.TempDir()
@@ -445,6 +481,8 @@ func TestRunInitWritesDefaultConfig(t *testing.T) {
 	}
 }
 
+// TestRunInitCreatesDecksRoot checks that RunInit creates the decks root
+// directory.
 func TestRunInitCreatesDecksRoot(t *testing.T) {
 	configDir := t.TempDir()
 	dataDir := t.TempDir()
@@ -465,6 +503,8 @@ func TestRunInitCreatesDecksRoot(t *testing.T) {
 	}
 }
 
+// TestRunInitRefusesOverwriteWithoutForce verifies that RunInit fails when
+// config.toml already exists and force is false.
 func TestRunInitRefusesOverwriteWithoutForce(t *testing.T) {
 	configDir := t.TempDir()
 	dataDir := t.TempDir()
@@ -485,6 +525,8 @@ func TestRunInitRefusesOverwriteWithoutForce(t *testing.T) {
 	}
 }
 
+// TestRunInitOverwritesWithForce checks that RunInit overwrites an existing
+// config.toml when force is true.
 func TestRunInitOverwritesWithForce(t *testing.T) {
 	configDir := t.TempDir()
 	dataDir := t.TempDir()
@@ -510,6 +552,8 @@ func TestRunInitOverwritesWithForce(t *testing.T) {
 	}
 }
 
+// TestRunInitPrintsSuccessSummary verifies that RunInit prints the paths of
+// the created config file and decks directory to stdout.
 func TestRunInitPrintsSuccessSummary(t *testing.T) {
 	configDir := t.TempDir()
 	dataDir := t.TempDir()
@@ -533,6 +577,8 @@ func TestRunInitPrintsSuccessSummary(t *testing.T) {
 	}
 }
 
+// TestRunInitIdempotentWithForce checks that running RunInit twice with force
+// produces the same config content both times.
 func TestRunInitIdempotentWithForce(t *testing.T) {
 	configDir := t.TempDir()
 	dataDir := t.TempDir()
@@ -556,6 +602,8 @@ func TestRunInitIdempotentWithForce(t *testing.T) {
 	}
 }
 
+// TestInitSubcommandCreatesFiles verifies that the init subcommand creates
+// config.toml and the decks root directory using the standard XDG paths.
 func TestInitSubcommandCreatesFiles(t *testing.T) {
 	configDir := t.TempDir()
 	dataDir := t.TempDir()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,4 +1,10 @@
-// Package config loads and provides default application configuration.
+// Package config loads and provides application settings for srs-tui.
+//
+// Configuration is read from a TOML file located at
+// <config-dir>/srs/config.toml, where <config-dir> defaults to
+// $XDG_CONFIG_HOME or ~/.config.  When the file is missing, Load
+// returns the built-in defaults.  All settings are optional; any
+// key omitted from the file keeps its default value.
 package config
 
 import (
@@ -9,22 +15,27 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/paths"
 )
 
+// PathsConfig holds directory-path settings.
 type PathsConfig struct {
 	DecksRoot string `toml:"decks_root"`
 }
 
+// ReviewConfig holds review-session settings.
 type ReviewConfig struct {
 	NewPerDay int `toml:"new_per_day"`
 }
 
+// EditorConfig holds external-editor settings.
 type EditorConfig struct {
 	Command string `toml:"command"`
 }
 
+// RenderConfig holds TUI rendering settings.
 type RenderConfig struct {
 	Style string `toml:"style"`
 }
 
+// Config is the top-level configuration aggregate.
 type Config struct {
 	Paths  PathsConfig  `toml:"paths"`
 	Review ReviewConfig `toml:"review"`
@@ -32,6 +43,7 @@ type Config struct {
 	Render RenderConfig `toml:"render"`
 }
 
+// Defaults returns a Config populated with built-in defaults.
 func Defaults() *Config {
 	return &Config{
 		Paths: PathsConfig{
@@ -49,6 +61,10 @@ func Defaults() *Config {
 	}
 }
 
+// Load reads config.toml from <configDir>/srs and returns the merged
+// result.  Missing files are treated as an empty config, so defaults
+// are always preserved.  Tilde characters in DecksRoot are expanded
+// to the user's home directory.
 func Load(configDir string) (*Config, error) {
 	cfg := Defaults()
 	p := filepath.Join(configDir, "srs", "config.toml")
@@ -66,6 +82,8 @@ func Load(configDir string) (*Config, error) {
 	return cfg, nil
 }
 
+// DefaultConfigContent returns the text embedded in a newly scaffolded
+// config.toml file, including commented documentation for every section.
 func DefaultConfigContent() string {
 	return `# [paths]
 # decks_root = ""    # Default: $XDG_DATA_HOME/srs/decks

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/config"
 )
 
+// TestLoadReturnsDefaultsWhenFileAbsent confirms that Load returns the
+// built-in defaults when no config.toml exists.
 func TestLoadReturnsDefaultsWhenFileAbsent(t *testing.T) {
 	cfg, err := config.Load(t.TempDir())
 	if err != nil {
@@ -30,6 +32,8 @@ func TestLoadReturnsDefaultsWhenFileAbsent(t *testing.T) {
 	}
 }
 
+// TestLoadParsesV1KeysFromConfigToml verifies that every documented config
+// key is read correctly from a real TOML file.
 func TestLoadParsesV1KeysFromConfigToml(t *testing.T) {
 	dir := t.TempDir()
 	srsDir := filepath.Join(dir, "srs")
@@ -72,6 +76,8 @@ style = "light"
 	}
 }
 
+// TestLoadPartialConfigKeepsDefaults checks that omitted sections fall back
+// to defaults rather than zero values.
 func TestLoadPartialConfigKeepsDefaults(t *testing.T) {
 	dir := t.TempDir()
 	srsDir := filepath.Join(dir, "srs")
@@ -103,6 +109,8 @@ new_per_day = 5
 	}
 }
 
+// TestLoadExpandsTildeInDecksRoot ensures that a leading "~" in decks_root
+// is expanded to the user's home directory.
 func TestLoadExpandsTildeInDecksRoot(t *testing.T) {
 	dir := t.TempDir()
 	srsDir := filepath.Join(dir, "srs")

--- a/internal/deck/deck.go
+++ b/internal/deck/deck.go
@@ -1,4 +1,5 @@
-// Package deck discovers decks and builds review queues from card files.
+// Package deck discovers SRS decks on disk and builds shuffled review queues
+// from the Markdown card files contained within each deck directory.
 package deck
 
 import (
@@ -9,6 +10,9 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/card"
 )
 
+// Discover returns the absolute paths of every immediate subdirectory inside
+// root. Only directories are returned; regular files are ignored. Symlinks to
+// directories are followed.
 func Discover(root string) ([]string, error) {
 	entries, err := os.ReadDir(root)
 	if err != nil {
@@ -28,6 +32,9 @@ func Discover(root string) ([]string, error) {
 	return decks, nil
 }
 
+// BuildQueue walks deckDir recursively, parses every .md file into a Card,
+// and returns the collected cards in random order. Files that cannot be
+// parsed as cards or that lack frontmatter are skipped.
 func BuildQueue(deckDir string) ([]*card.Card, error) {
 	var cards []*card.Card
 	err := filepath.WalkDir(deckDir, func(path string, d os.DirEntry, err error) error {

--- a/internal/fsrs/fsrs.go
+++ b/internal/fsrs/fsrs.go
@@ -1,4 +1,6 @@
-// Package fsrs wraps the Free Spaced Repetition Scheduler for card scheduling.
+// Package fsrs provides scheduling logic for spaced-repetition cards using the
+// FSRS (Free Spaced Repetition Scheduler) algorithm. It wraps the open-spaced-repetition
+// go-fsrs library with domain-specific types and helpers used by the application.
 package fsrs
 
 import (
@@ -8,24 +10,32 @@ import (
 	fsrslib "github.com/open-spaced-repetition/go-fsrs/v4"
 )
 
+// State represents the learning stage of a card in the FSRS algorithm.
 type State string
 
 const (
-	StateNew        State = "new"
-	StateLearning   State = "learning"
-	StateReview     State = "review"
+	// StateNew indicates the card has never been reviewed.
+	StateNew State = "new"
+	// StateLearning indicates the card is in the initial learning phase.
+	StateLearning State = "learning"
+	// StateReview indicates the card is in the regular review phase.
+	StateReview State = "review"
+	// StateRelearning indicates the card has lapsed and is being re-learned.
 	StateRelearning State = "relearning"
 )
 
+// CardState holds the scheduling state of a card at a point in time.
 type CardState struct {
 	State      State
-	Due       time.Time
+	Due        time.Time
 	Stability  float64
 	Difficulty float64
-	Reps      int
-	Lapses    int
+	Reps       int
+	Lapses     int
 }
 
+// IntervalPreview shows the projected next state and interval for a given
+// user rating without actually updating the card.
 type IntervalPreview struct {
 	Rating   int
 	State    State
@@ -33,6 +43,7 @@ type IntervalPreview struct {
 	Interval time.Duration
 }
 
+// stateFromLib converts a go-fsrs State to the package State type.
 func stateFromLib(s fsrslib.State) State {
 	switch s {
 	case fsrslib.New:
@@ -47,6 +58,7 @@ func stateFromLib(s fsrslib.State) State {
 	return ""
 }
 
+// stateToLib converts a package State to the go-fsrs State type.
 func stateToLib(s State) fsrslib.State {
 	switch s {
 	case StateNew:
@@ -61,6 +73,7 @@ func stateToLib(s State) fsrslib.State {
 	return fsrslib.New
 }
 
+// toLibCard converts a CardState to the go-fsrs Card type.
 func toLibCard(c CardState) fsrslib.Card {
 	return fsrslib.Card{
 		Due:        c.Due,
@@ -72,19 +85,25 @@ func toLibCard(c CardState) fsrslib.Card {
 	}
 }
 
+// fromLibCard converts a go-fsrs Card to the package CardState type.
 func fromLibCard(c fsrslib.Card) CardState {
 	return CardState{
 		State:      stateFromLib(c.State),
-		Due:       c.Due,
+		Due:        c.Due,
 		Stability:  c.Stability,
 		Difficulty: c.Difficulty,
-		Reps:      int(c.Reps),
-		Lapses:    int(c.Lapses),
+		Reps:       int(c.Reps),
+		Lapses:     int(c.Lapses),
 	}
 }
 
+// defaultFSRS is the shared FSRS scheduler instance configured with default
+// parameters.
 var defaultFSRS = fsrslib.NewFSRS(fsrslib.DefaultParam())
 
+// Preview returns the possible next states and intervals for a card if it were
+// reviewed right now. The returned slice contains one entry for each of the
+// four FSRS ratings (Again, Hard, Good, Easy). It does not modify the card.
 func Preview(card CardState, now time.Time) []IntervalPreview {
 	libCard := toLibCard(card)
 	log := defaultFSRS.Repeat(libCard, now)
@@ -109,6 +128,8 @@ func Preview(card CardState, now time.Time) []IntervalPreview {
 	return previews
 }
 
+// ParseTime parses an RFC3339 string into a time.Time. It returns the zero
+// value for an empty string or on parse failure.
 func ParseTime(s string) time.Time {
 	if s == "" {
 		return time.Time{}
@@ -117,6 +138,8 @@ func ParseTime(s string) time.Time {
 	return t
 }
 
+// NormalizeState converts a raw string into a State. It returns StateNew for
+// an empty string.
 func NormalizeState(s string) State {
 	if s == "" {
 		return StateNew
@@ -124,6 +147,9 @@ func NormalizeState(s string) State {
 	return State(s)
 }
 
+// Rate applies a user rating (1–4) to a card at the given time and returns the
+// updated card state, a preview of all four rating outcomes, and any error.
+// Rating values map to FSRS: 1 = Again, 2 = Hard, 3 = Good, 4 = Easy.
 func Rate(card CardState, rating int, now time.Time) (CardState, []IntervalPreview, error) {
 	if rating < 1 || rating > 4 {
 		return CardState{}, nil, fmt.Errorf("fsrs: rating %d out of range [1,4]", rating)

--- a/internal/paths/paths.go
+++ b/internal/paths/paths.go
@@ -1,4 +1,6 @@
-// Package paths resolves XDG Base Directory paths for config, data, and state.
+// Package paths resolves directories according to the XDG Base Directory
+// specification, providing sensible fallbacks when the environment variables
+// are unset.
 package paths
 
 import (
@@ -6,6 +8,8 @@ import (
 	"path/filepath"
 )
 
+// ConfigHome returns the XDG configuration directory ($XDG_CONFIG_HOME,
+// or ~/.config by default).
 func ConfigHome() string {
 	if v := os.Getenv("XDG_CONFIG_HOME"); v != "" {
 		return v
@@ -14,6 +18,8 @@ func ConfigHome() string {
 	return filepath.Join(home, ".config")
 }
 
+// DataHome returns the XDG data directory ($XDG_DATA_HOME, or
+// ~/.local/share by default).
 func DataHome() string {
 	if v := os.Getenv("XDG_DATA_HOME"); v != "" {
 		return v
@@ -22,6 +28,8 @@ func DataHome() string {
 	return filepath.Join(home, ".local", "share")
 }
 
+// StateHome returns the XDG state directory ($XDG_STATE_HOME, or
+// ~/.local/state by default).
 func StateHome() string {
 	if v := os.Getenv("XDG_STATE_HOME"); v != "" {
 		return v
@@ -30,6 +38,9 @@ func StateHome() string {
 	return filepath.Join(home, ".local", "state")
 }
 
+// DecksRoot returns the root directory for deck storage.  If override is
+// non-empty it is used verbatim (with tilde expansion); otherwise the
+// default $XDG_DATA_HOME/srs/decks is returned.
 func DecksRoot(override string) string {
 	if override != "" {
 		return ExpandHome(override)
@@ -37,6 +48,7 @@ func DecksRoot(override string) string {
 	return filepath.Join(DataHome(), "srs", "decks")
 }
 
+// ExpandHome replaces a leading "~" in p with the user's home directory.
 func ExpandHome(p string) string {
 	if len(p) > 0 && p[0] == '~' {
 		home, _ := os.UserHomeDir()

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/paths"
 )
 
+// TestDataHomeUsesXDGDataHome checks that DataHome respects $XDG_DATA_HOME.
 func TestDataHomeUsesXDGDataHome(t *testing.T) {
 	custom := filepath.Join(t.TempDir(), "xdg-data")
 	os.Setenv("XDG_DATA_HOME", custom)
@@ -21,6 +22,7 @@ func TestDataHomeUsesXDGDataHome(t *testing.T) {
 	}
 }
 
+// TestDataHomeFallsBackToDefault verifies the default ~/.local/share fallback.
 func TestDataHomeFallsBackToDefault(t *testing.T) {
 	os.Unsetenv("XDG_DATA_HOME")
 	home, _ := os.UserHomeDir()
@@ -32,6 +34,7 @@ func TestDataHomeFallsBackToDefault(t *testing.T) {
 	}
 }
 
+// TestDecksRootDefault confirms DecksRoot("") returns the standard SRS decks path.
 func TestDecksRootDefault(t *testing.T) {
 	os.Unsetenv("XDG_DATA_HOME")
 	home, _ := os.UserHomeDir()
@@ -43,6 +46,7 @@ func TestDecksRootDefault(t *testing.T) {
 	}
 }
 
+// TestDecksRootOverride checks that a non-empty override is passed through verbatim.
 func TestDecksRootOverride(t *testing.T) {
 	got := paths.DecksRoot("/custom/path")
 	want := "/custom/path"
@@ -51,6 +55,7 @@ func TestDecksRootOverride(t *testing.T) {
 	}
 }
 
+// TestExpandHome verifies tilde expansion to the user's home directory.
 func TestExpandHome(t *testing.T) {
 	home, _ := os.UserHomeDir()
 	got := paths.ExpandHome("~/my/decks")
@@ -60,6 +65,7 @@ func TestExpandHome(t *testing.T) {
 	}
 }
 
+// TestExpandHomeNoTilde ensures that absolute paths without a tilde are left untouched.
 func TestExpandHomeNoTilde(t *testing.T) {
 	got := paths.ExpandHome("/absolute/path")
 	want := "/absolute/path"
@@ -68,6 +74,7 @@ func TestExpandHomeNoTilde(t *testing.T) {
 	}
 }
 
+// TestDecksRootExpandsTilde confirms that DecksRoot expands a leading "~".
 func TestDecksRootExpandsTilde(t *testing.T) {
 	home, _ := os.UserHomeDir()
 	got := paths.DecksRoot("~/my-decks")
@@ -77,6 +84,7 @@ func TestDecksRootExpandsTilde(t *testing.T) {
 	}
 }
 
+// TestStateHomeUsesXDGStateHome checks that StateHome respects $XDG_STATE_HOME.
 func TestStateHomeUsesXDGStateHome(t *testing.T) {
 	custom := filepath.Join(t.TempDir(), "xdg-state")
 	os.Setenv("XDG_STATE_HOME", custom)
@@ -88,6 +96,7 @@ func TestStateHomeUsesXDGStateHome(t *testing.T) {
 	}
 }
 
+// TestConfigHomeUsesXDGConfigHome checks that ConfigHome respects $XDG_CONFIG_HOME.
 func TestConfigHomeUsesXDGConfigHome(t *testing.T) {
 	custom := filepath.Join(t.TempDir(), "xdg-config")
 	os.Setenv("XDG_CONFIG_HOME", custom)
@@ -99,6 +108,7 @@ func TestConfigHomeUsesXDGConfigHome(t *testing.T) {
 	}
 }
 
+// TestConfigHomeFallsBackToDefault verifies the default ~/.config fallback.
 func TestConfigHomeFallsBackToDefault(t *testing.T) {
 	os.Unsetenv("XDG_CONFIG_HOME")
 	home, _ := os.UserHomeDir()
@@ -110,6 +120,7 @@ func TestConfigHomeFallsBackToDefault(t *testing.T) {
 	}
 }
 
+// TestStateHomeFallsBackToDefault verifies the default ~/.local/state fallback.
 func TestStateHomeFallsBackToDefault(t *testing.T) {
 	os.Unsetenv("XDG_STATE_HOME")
 	home, _ := os.UserHomeDir()

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,4 +1,6 @@
-// Package store persists review logs and atomically rewrites card files.
+// Package store persists review logs and card state for SRS decks.
+// It writes JSONL review entries and performs atomic rewrites of
+// Markdown card files so that crashes never leave data partially updated.
 package store
 
 import (
@@ -13,23 +15,29 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/fsrs"
 )
 
+// LogEntry is a single review event recorded as one JSON line.
 type LogEntry struct {
-	Schema     int            `json:"schema"`
-	TS         time.Time      `json:"ts"`
-	CardID     string         `json:"card_id"`
-	ClozeGroup *int           `json:"cloze_group,omitempty"`
-	Rating     int            `json:"rating"`
+	Schema int       `json:"schema"`
+	TS     time.Time `json:"ts"`
+	CardID string    `json:"card_id"`
+	// ClozeGroup is reserved for future cloze-deletion grouping; currently unused.
+	ClozeGroup *int `json:"cloze_group,omitempty"`
+	Rating     int  `json:"rating"`
+	// DurationMs is reserved for future review-duration tracking; currently unused.
 	DurationMs int64          `json:"duration_ms"`
 	Prev       fsrs.CardState `json:"prev"`
 	Next       fsrs.CardState `json:"next"`
 }
 
+// Store manages the on-disk state for one deck.
 type Store struct {
 	stateDir string
 	deckSlug string
 	logPath  string
 }
 
+// NewStore creates a Store that persists data under stateDir for deckSlug.
+// Review logs are written to stateDir/deckSlug.jsonl.
 func NewStore(stateDir, deckSlug string) *Store {
 	return &Store{
 		stateDir: stateDir,
@@ -38,6 +46,8 @@ func NewStore(stateDir, deckSlug string) *Store {
 	}
 }
 
+// AppendLog marshals entry as JSON and appends it to the review log
+// file, creating the state directory and log file if necessary.
 func (s *Store) AppendLog(entry LogEntry) error {
 	if err := os.MkdirAll(s.stateDir, 0o755); err != nil {
 		return err
@@ -60,6 +70,9 @@ func (s *Store) AppendLog(entry LogEntry) error {
 	return f.Sync()
 }
 
+// AtomicWriteFile writes data to path by creating a temporary file in the
+// same directory, syncing it, and renaming it over path. This guarantees
+// that path never contains a partially written file.
 func AtomicWriteFile(path string, data []byte) error {
 	dir := filepath.Dir(path)
 	tmp, err := os.CreateTemp(dir, "*.tmp")
@@ -89,10 +102,13 @@ func AtomicWriteFile(path string, data []byte) error {
 	return nil
 }
 
+// RewriteCard serializes c and atomically overwrites cardPath.
 func (s *Store) RewriteCard(cardPath string, c *card.Card) error {
 	return AtomicWriteFile(cardPath, c.Serialize())
 }
 
+// Persist records a review log entry and updates the on-disk card file.
+// Both operations must succeed; the log is written before the card is rewritten.
 func (s *Store) Persist(entry LogEntry, cardPath string, c *card.Card) error {
 	if err := s.AppendLog(entry); err != nil {
 		return fmt.Errorf("store: persist log: %w", err)
@@ -103,6 +119,8 @@ func (s *Store) Persist(entry LogEntry, cardPath string, c *card.Card) error {
 	return nil
 }
 
+// EnsureID assigns a UUID v7 to c if it does not already have an ID.
+// It returns true when an ID was assigned and false if the card already had one.
 func EnsureID(c *card.Card) bool {
 	if c.ID != "" {
 		return false
@@ -115,6 +133,11 @@ func EnsureID(c *card.Card) bool {
 	return true
 }
 
+// StateDir returns the directory where review logs are stored.
 func (s *Store) StateDir() string { return s.stateDir }
+
+// DeckSlug returns the identifier used for this deck's log file name.
 func (s *Store) DeckSlug() string { return s.deckSlug }
-func (s *Store) LogPath() string  { return s.logPath }
+
+// LogPath returns the full path to the JSONL review log file.
+func (s *Store) LogPath() string { return s.logPath }

--- a/internal/tui/review.go
+++ b/internal/tui/review.go
@@ -1,4 +1,13 @@
-// Package tui provides the interactive terminal review session.
+// Package tui implements the Bubble Tea review interface for spaced-repetition
+// cards. A review session follows a three-state lifecycle:
+//
+//   1. Front — the question side is displayed.
+//   2. Back — pressing Space or Enter reveals the answer and shows interval
+//      previews (again, hard, good, easy) computed by the scheduler.
+//   3. Rate — pressing a rating key (1–4) applies the score via RateFunc,
+//      advances to the next card, and returns to the front state.
+//
+// When every card has been rated the session ends and View signals completion.
 package tui
 
 import (
@@ -11,8 +20,13 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/fsrs"
 )
 
+// RateFunc applies a user rating to a card and returns the resulting state,
+// interval previews for all possible ratings, and any error.
 type RateFunc func(c *card.Card, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, error)
 
+// ReviewModel is a Bubble Tea model that drives a flash-card review session.
+// It manages a deck of cards, tracks which side is visible, and coordinates
+// with a RateFunc to schedule cards after each rating.
 type ReviewModel struct {
 	cards       []*card.Card
 	index       int
@@ -23,6 +37,9 @@ type ReviewModel struct {
 	done        bool
 }
 
+// NewReviewModel creates a ReviewModel for the given cards. The rateFunc is
+// invoked each time the user presses a rating key (1–4) while the back side
+// is visible.
 func NewReviewModel(cards []*card.Card, rateFunc RateFunc) ReviewModel {
 	r, _ := glamour.NewTermRenderer(glamour.WithStandardStyle("dark"))
 	return ReviewModel{
@@ -32,18 +49,28 @@ func NewReviewModel(cards []*card.Card, rateFunc RateFunc) ReviewModel {
 	}
 }
 
+// ShowingBack reports whether the answer side of the current card is visible.
 func (m ReviewModel) ShowingBack() bool {
 	return m.showingBack
 }
 
+// CurrentIndex returns the position of the card currently being reviewed.
 func (m ReviewModel) CurrentIndex() int {
 	return m.index
 }
 
+// Init implements tea.Model.
 func (m ReviewModel) Init() tea.Cmd {
 	return nil
 }
 
+// Update implements tea.Model. It handles the review lifecycle:
+//
+//   • Space / Enter — flip the current card to its back side and compute
+//     interval previews via the fsrs scheduler.
+//   • 1–4 — rate the card (only valid while the back is showing), advance
+//     to the next card, and clear previews.
+//   • q — emit tea.Quit to exit the application.
 func (m ReviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
@@ -86,6 +113,9 @@ func (m ReviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
+// View implements tea.Model. It renders the front or back of the current
+// card (markdown formatted via glamour) and, when the back is showing,
+// appends the interval previews returned by the scheduler.
 func (m ReviewModel) View() string {
 	if len(m.cards) == 0 {
 		return "No cards in this deck.\nPress q to quit."
@@ -105,17 +135,21 @@ func (m ReviewModel) View() string {
 	return rendered
 }
 
+// cardStateFromCard converts a card.Card into the fsrs.CardState used by the
+// scheduler.
 func cardStateFromCard(c *card.Card) fsrs.CardState {
 	return fsrs.CardState{
 		State:      fsrs.NormalizeState(c.State),
-		Due:       fsrs.ParseTime(c.Due),
+		Due:        fsrs.ParseTime(c.Due),
 		Stability:  c.Stability,
 		Difficulty: c.Difficulty,
-		Reps:      c.Reps,
-		Lapses:    c.Lapses,
+		Reps:       c.Reps,
+		Lapses:     c.Lapses,
 	}
 }
 
+// formatPreviews renders a list of interval previews as rating labels with
+// human-readable intervals (e.g. "1 Again (1m)").
 func formatPreviews(previews []fsrs.IntervalPreview) string {
 	labels := map[int]string{1: "Again", 2: "Hard", 3: "Good", 4: "Easy"}
 	var s string
@@ -127,6 +161,8 @@ func formatPreviews(previews []fsrs.IntervalPreview) string {
 	return s
 }
 
+// formatDuration converts a time.Duration into a compact string:
+// "< 1m" for sub-minute, "%dm" for minutes, "%dh" for hours, and "%dd" for days.
 func formatDuration(d time.Duration) string {
 	if d < time.Minute {
 		return "< 1m"

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,3 +1,6 @@
+// Package version_test contains unit tests for the version resolution package.
+// Tests exercise all three tiers (ldflags, BuildInfo, sentinel defaults) and
+// verify JSON serialization.
 package version_test
 
 import (
@@ -8,6 +11,8 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/version"
 )
 
+// TestGetReturnsSentinelDefaultsWhenNothingResolved checks the fallback
+// dev/unknown/unknown/default values when no ldflags or BuildInfo are present.
 func TestGetReturnsSentinelDefaultsWhenNothingResolved(t *testing.T) {
 	defer version.SwapForTest("", "", "", func() (*debug.BuildInfo, bool) { return nil, false })()
 
@@ -27,6 +32,8 @@ func TestGetReturnsSentinelDefaultsWhenNothingResolved(t *testing.T) {
 	}
 }
 
+// TestGetUsesLdflagsValuesWhenSet verifies that injected ldflags variables
+// take precedence over BuildInfo.
 func TestGetUsesLdflagsValuesWhenSet(t *testing.T) {
 	defer version.SwapForTest("v1.2.3", "abc1234", "2026-05-03T12:00:00Z", func() (*debug.BuildInfo, bool) {
 		t.Fatal("readBuildInfo should not be consulted when ldflags vars are set")
@@ -49,6 +56,8 @@ func TestGetUsesLdflagsValuesWhenSet(t *testing.T) {
 	}
 }
 
+// TestGetReadsBuildInfoWhenLdflagsEmpty checks that BuildInfo is consulted
+// when ldflags variables are empty, extracting version, commit, and time.
 func TestGetReadsBuildInfoWhenLdflagsEmpty(t *testing.T) {
 	fixture := &debug.BuildInfo{
 		Main: debug.Module{Version: "v0.5.1"},
@@ -75,6 +84,8 @@ func TestGetReadsBuildInfoWhenLdflagsEmpty(t *testing.T) {
 	}
 }
 
+// TestGetUsesDefaultsWhenBuildInfoMainVersionDevel ensures that a (devel)
+// BuildInfo version falls through to sentinel defaults.
 func TestGetUsesDefaultsWhenBuildInfoMainVersionDevel(t *testing.T) {
 	fixture := &debug.BuildInfo{
 		Main: debug.Module{Version: "(devel)"},
@@ -91,6 +102,8 @@ func TestGetUsesDefaultsWhenBuildInfoMainVersionDevel(t *testing.T) {
 	}
 }
 
+// TestInfoJSONRoundTrip validates that Info marshals to JSON with the
+// expected keys and unmarshals back without loss.
 func TestInfoJSONRoundTrip(t *testing.T) {
 	original := version.Info{
 		Version: "v0.2.0",


### PR DESCRIPTION
## Summary

Re-applies comprehensive Go doc comments across all packages after they were accidentally stripped during the rebase of `srs-tui-34-draft-context-doc-verify` (PR #41).

### What happened

The original documentation PRs (#35–#39) added detailed package, type, function, and test-level doc comments. When `srs-tui-34-draft-context-doc-verify` was rebased onto `main`, commit `cf16afb` replaced all those detailed comments with minimal one-line package stubs, effectively deleting ~300 lines of documentation.

Additionally, commit `4b3d9eb` on `main` (message: `test`) was a bad cherry-pick that left unresolved `<<<<<<< HEAD` conflict markers in `internal/cli/cli.go` and `internal/cli/cli_test.go`.

### What was restored

Detailed comments re-added to:
- `cmd/srs/main.go`
- `internal/card` (package, types, functions, tests)
- `internal/config` (package, types, functions, tests)
- `internal/deck` (package, functions)
- `internal/fsrs` (package, types, functions)
- `internal/paths` (package, functions, tests)
- `internal/store` (package, types, functions)
- `internal/tui/review.go` (package, types, functions)
- `internal/version` (package, tests)
- `internal/cli` (resolved merge conflicts + restored comments)

### Post-doc code changes preserved

- `c1ab0e4` — q-key quit fix in `tui/review.go`
- `f5e8266` — `card.NewCard` and `SerializeNew`
- `fbfa2c7` — version package refactor using `version.Get()`

### Verification

- `go vet ./...` — clean
- `go test ./...` — all 9 packages pass