### PR TITLE
chore(deps): add Dependabot configuration for gomod and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      minor-patch:
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      minor-patch:
+        update-types:
+          - minor
+          - patch
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

Add `.github/dependabot.yml` to automate dependency updates for Go modules and GitHub Actions.

## Configuration

| Setting | Value |
|---|---|
| Ecosystems | `gomod`, `github-actions` |
| Schedule | weekly |
| Grouped updates | minor + patch |
| Commit prefix | `chore` with scope |
| Open PR limit | 5 per ecosystem |

## Acceptance criteria

- [x] `.github/dependabot.yml` exists with weekly schedule
- [x] Covers `gomod` and `github-actions` ecosystems
- [x] Minor/patch updates are grouped
- [x] Commit prefix `chore` with scope
- [x] Five PR limit per ecosystem

Closes: #23