### PR TITLE
chore(tooling): add golangci-lint config and justfile

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,20 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - revive
+    - staticcheck
+    - unused
+
+  settings:
+    revive:
+      rules:
+        - name: exported
+
+formatters:
+  enable:
+    - gofmt

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -233,7 +233,7 @@ func newVersionCmd() *cobra.Command {
 			info := version.Get()
 			switch format {
 			case "text":
-				fmt.Fprintf(cmd.OutOrStdout(), "srs %s\ncommit: %s\ndate:   %s\n", info.Version, info.Commit, info.Date)
+				_, _ = fmt.Fprintf(cmd.OutOrStdout(), "srs %s\ncommit: %s\ndate:   %s\n", info.Version, info.Commit, info.Date)
 			case "json":
 				enc := json.NewEncoder(cmd.OutOrStdout())
 				return enc.Encode(info)
@@ -275,7 +275,7 @@ func RunInit(configDir, dataDir string, force bool, stdout, stderr io.Writer) er
 	configPath := filepath.Join(srsConfigDir, "config.toml")
 
 	if _, err := os.Stat(configPath); err == nil && !force {
-		fmt.Fprintf(stderr, "config.toml already exists; use --force to overwrite\n")
+		_, _ = fmt.Fprintf(stderr, "config.toml already exists; use --force to overwrite\n")
 		return fmt.Errorf("config.toml already exists")
 	}
 
@@ -292,7 +292,7 @@ func RunInit(configDir, dataDir string, force bool, stdout, stderr io.Writer) er
 		return fmt.Errorf("create decks root: %w", err)
 	}
 
-	fmt.Fprintf(stdout, "Created %s\nCreated %s\n", configPath, decksRoot)
+	_, _ = fmt.Fprintf(stdout, "Created %s\nCreated %s\n", configPath, decksRoot)
 	return nil
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -153,7 +153,9 @@ func TestMakeRateFuncPersistsRating(t *testing.T) {
 		Back:     "A\n",
 		FilePath: filepath.Join(cardDir, "card-1.md"),
 	}
-	os.WriteFile(c.FilePath, c.Serialize(), 0o644)
+	if err := os.WriteFile(c.FilePath, c.Serialize(), 0o644); err != nil {
+		t.Fatalf("write card file: %v", err)
+	}
 
 	s := store.NewStore(stateDir, "testdeck")
 	rateFunc := cli.MakeRateFunc(s)
@@ -175,7 +177,7 @@ func TestMakeRateFuncPersistsRating(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open jsonl: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	lineCount := 0
@@ -434,7 +436,9 @@ func TestMakeRateFuncAssignsID(t *testing.T) {
 		Back:     "A\n",
 		FilePath: filepath.Join(cardDir, "noid.md"),
 	}
-	os.WriteFile(c.FilePath, c.Serialize(), 0o644)
+	if err := os.WriteFile(c.FilePath, c.Serialize(), 0o644); err != nil {
+		t.Fatalf("write card file: %v", err)
+	}
 
 	s := store.NewStore(stateDir, "testdeck")
 	rateFunc := cli.MakeRateFunc(s)
@@ -539,7 +543,9 @@ func TestRunInitOverwritesWithForce(t *testing.T) {
 	configPath := filepath.Join(configDir, "srs", "config.toml")
 	original, _ := os.ReadFile(configPath)
 
-	os.WriteFile(configPath, append(original, []byte("# extra\n")...), 0o644)
+	if err := os.WriteFile(configPath, append(original, []byte("# extra\n")...), 0o644); err != nil {
+		t.Fatalf("write config file: %v", err)
+	}
 
 	var stdout2, stderr2 bytes.Buffer
 	if err := cli.RunInit(configDir, dataDir, true, &stdout2, &stderr2); err != nil {
@@ -607,10 +613,22 @@ func TestRunInitIdempotentWithForce(t *testing.T) {
 func TestInitSubcommandCreatesFiles(t *testing.T) {
 	configDir := t.TempDir()
 	dataDir := t.TempDir()
-	os.Setenv("XDG_CONFIG_HOME", configDir)
-	os.Setenv("XDG_DATA_HOME", dataDir)
-	defer os.Unsetenv("XDG_CONFIG_HOME")
-	defer os.Unsetenv("XDG_DATA_HOME")
+	if err := os.Setenv("XDG_CONFIG_HOME", configDir); err != nil {
+		t.Fatalf("setenv: %v", err)
+	}
+	if err := os.Setenv("XDG_DATA_HOME", dataDir); err != nil {
+		t.Fatalf("setenv: %v", err)
+	}
+	defer func() {
+		if err := os.Unsetenv("XDG_CONFIG_HOME"); err != nil {
+			t.Fatalf("unsetenv: %v", err)
+		}
+	}()
+	defer func() {
+		if err := os.Unsetenv("XDG_DATA_HOME"); err != nil {
+			t.Fatalf("unsetenv: %v", err)
+		}
+	}()
 
 	buf := new(bytes.Buffer)
 	cli.SetOutput(buf)

--- a/internal/deck/deck_test.go
+++ b/internal/deck/deck_test.go
@@ -36,10 +36,18 @@ func writeBasicCard(t *testing.T, dir, id, front, back string) {
 // subdirectories and ignores regular files.
 func TestDiscoverDecks(t *testing.T) {
 	root := t.TempDir()
-	os.MkdirAll(filepath.Join(root, "french"), 0o755)
-	os.MkdirAll(filepath.Join(root, "golang"), 0o755)
-	os.MkdirAll(filepath.Join(root, "golang", "basics"), 0o755)
-	os.WriteFile(filepath.Join(root, "random.txt"), []byte("not a deck"), 0o644)
+	if err := os.MkdirAll(filepath.Join(root, "french"), 0o755); err != nil {
+		t.Fatalf("mkdir french: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "golang"), 0o755); err != nil {
+		t.Fatalf("mkdir golang: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(root, "golang", "basics"), 0o755); err != nil {
+		t.Fatalf("mkdir golang/basics: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "random.txt"), []byte("not a deck"), 0o644); err != nil {
+		t.Fatalf("write random.txt: %v", err)
+	}
 
 	got, err := deck.Discover(root)
 	if err != nil {
@@ -68,8 +76,12 @@ func TestDiscoverDecks(t *testing.T) {
 func TestDiscoverFollowsSymlinks(t *testing.T) {
 	root := t.TempDir()
 	realDir := t.TempDir()
-	os.MkdirAll(filepath.Join(realDir, "cards"), 0o755)
-	os.Symlink(realDir, filepath.Join(root, "linked"))
+	if err := os.MkdirAll(filepath.Join(realDir, "cards"), 0o755); err != nil {
+		t.Fatalf("mkdir cards: %v", err)
+	}
+	if err := os.Symlink(realDir, filepath.Join(root, "linked")); err != nil {
+		t.Fatalf("symlink linked: %v", err)
+	}
 
 	got, err := deck.Discover(root)
 	if err != nil {
@@ -95,7 +107,9 @@ func TestDiscoverFollowsSymlinks(t *testing.T) {
 func TestQueueContainsAllCardsShuffled(t *testing.T) {
 	root := t.TempDir()
 	deckDir := filepath.Join(root, "mydeck")
-	os.MkdirAll(deckDir, 0o755)
+	if err := os.MkdirAll(deckDir, 0o755); err != nil {
+		t.Fatalf("mkdir deck: %v", err)
+	}
 
 	writeBasicCard(t, deckDir, "id-1", "Q1", "A1")
 	writeBasicCard(t, deckDir, "id-2", "Q2", "A2")
@@ -125,10 +139,14 @@ func TestQueueContainsAllCardsShuffled(t *testing.T) {
 func TestQueueSkipsNonCardFiles(t *testing.T) {
 	root := t.TempDir()
 	deckDir := filepath.Join(root, "mydeck")
-	os.MkdirAll(deckDir, 0o755)
+	if err := os.MkdirAll(deckDir, 0o755); err != nil {
+		t.Fatalf("mkdir deck: %v", err)
+	}
 
 	writeBasicCard(t, deckDir, "id-1", "Q1", "A1")
-	os.WriteFile(filepath.Join(deckDir, "readme.md"), []byte("# Deck\nNo frontmatter\n"), 0o644)
+	if err := os.WriteFile(filepath.Join(deckDir, "readme.md"), []byte("# Deck\nNo frontmatter\n"), 0o644); err != nil {
+		t.Fatalf("write readme: %v", err)
+	}
 
 	q, err := deck.BuildQueue(deckDir)
 	if err != nil {

--- a/internal/paths/paths_test.go
+++ b/internal/paths/paths_test.go
@@ -12,8 +12,14 @@ import (
 // TestDataHomeUsesXDGDataHome checks that DataHome respects $XDG_DATA_HOME.
 func TestDataHomeUsesXDGDataHome(t *testing.T) {
 	custom := filepath.Join(t.TempDir(), "xdg-data")
-	os.Setenv("XDG_DATA_HOME", custom)
-	defer os.Unsetenv("XDG_DATA_HOME")
+	if err := os.Setenv("XDG_DATA_HOME", custom); err != nil {
+		t.Fatalf("setenv: %v", err)
+	}
+	defer func() {
+		if err := os.Unsetenv("XDG_DATA_HOME"); err != nil {
+			t.Fatalf("unsetenv: %v", err)
+		}
+	}()
 
 	got := paths.DataHome()
 	want := custom
@@ -24,7 +30,9 @@ func TestDataHomeUsesXDGDataHome(t *testing.T) {
 
 // TestDataHomeFallsBackToDefault verifies the default ~/.local/share fallback.
 func TestDataHomeFallsBackToDefault(t *testing.T) {
-	os.Unsetenv("XDG_DATA_HOME")
+	if err := os.Unsetenv("XDG_DATA_HOME"); err != nil {
+		t.Fatalf("unsetenv: %v", err)
+	}
 	home, _ := os.UserHomeDir()
 	want := filepath.Join(home, ".local", "share")
 
@@ -36,7 +44,9 @@ func TestDataHomeFallsBackToDefault(t *testing.T) {
 
 // TestDecksRootDefault confirms DecksRoot("") returns the standard SRS decks path.
 func TestDecksRootDefault(t *testing.T) {
-	os.Unsetenv("XDG_DATA_HOME")
+	if err := os.Unsetenv("XDG_DATA_HOME"); err != nil {
+		t.Fatalf("unsetenv: %v", err)
+	}
 	home, _ := os.UserHomeDir()
 	want := filepath.Join(home, ".local", "share", "srs", "decks")
 
@@ -87,8 +97,14 @@ func TestDecksRootExpandsTilde(t *testing.T) {
 // TestStateHomeUsesXDGStateHome checks that StateHome respects $XDG_STATE_HOME.
 func TestStateHomeUsesXDGStateHome(t *testing.T) {
 	custom := filepath.Join(t.TempDir(), "xdg-state")
-	os.Setenv("XDG_STATE_HOME", custom)
-	defer os.Unsetenv("XDG_STATE_HOME")
+	if err := os.Setenv("XDG_STATE_HOME", custom); err != nil {
+		t.Fatalf("setenv: %v", err)
+	}
+	defer func() {
+		if err := os.Unsetenv("XDG_STATE_HOME"); err != nil {
+			t.Fatalf("unsetenv: %v", err)
+		}
+	}()
 
 	got := paths.StateHome()
 	if got != custom {
@@ -99,8 +115,14 @@ func TestStateHomeUsesXDGStateHome(t *testing.T) {
 // TestConfigHomeUsesXDGConfigHome checks that ConfigHome respects $XDG_CONFIG_HOME.
 func TestConfigHomeUsesXDGConfigHome(t *testing.T) {
 	custom := filepath.Join(t.TempDir(), "xdg-config")
-	os.Setenv("XDG_CONFIG_HOME", custom)
-	defer os.Unsetenv("XDG_CONFIG_HOME")
+	if err := os.Setenv("XDG_CONFIG_HOME", custom); err != nil {
+		t.Fatalf("setenv: %v", err)
+	}
+	defer func() {
+		if err := os.Unsetenv("XDG_CONFIG_HOME"); err != nil {
+			t.Fatalf("unsetenv: %v", err)
+		}
+	}()
 
 	got := paths.ConfigHome()
 	if got != custom {
@@ -110,7 +132,9 @@ func TestConfigHomeUsesXDGConfigHome(t *testing.T) {
 
 // TestConfigHomeFallsBackToDefault verifies the default ~/.config fallback.
 func TestConfigHomeFallsBackToDefault(t *testing.T) {
-	os.Unsetenv("XDG_CONFIG_HOME")
+	if err := os.Unsetenv("XDG_CONFIG_HOME"); err != nil {
+		t.Fatalf("unsetenv: %v", err)
+	}
 	home, _ := os.UserHomeDir()
 	want := filepath.Join(home, ".config")
 
@@ -122,7 +146,9 @@ func TestConfigHomeFallsBackToDefault(t *testing.T) {
 
 // TestStateHomeFallsBackToDefault verifies the default ~/.local/state fallback.
 func TestStateHomeFallsBackToDefault(t *testing.T) {
-	os.Unsetenv("XDG_STATE_HOME")
+	if err := os.Unsetenv("XDG_STATE_HOME"); err != nil {
+		t.Fatalf("unsetenv: %v", err)
+	}
 	home, _ := os.UserHomeDir()
 	want := filepath.Join(home, ".local", "state")
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -57,7 +57,7 @@ func (s *Store) AppendLog(entry LogEntry) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	line, err := json.Marshal(entry)
 	if err != nil {
@@ -82,21 +82,21 @@ func AtomicWriteFile(path string, data []byte) error {
 	tmpPath := tmp.Name()
 
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("atomic write: write temp: %w", err)
 	}
 	if err := tmp.Sync(); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("atomic write: sync temp: %w", err)
 	}
 	if err := tmp.Close(); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("atomic write: close temp: %w", err)
 	}
 	if err := os.Rename(tmpPath, path); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return fmt.Errorf("atomic write: rename temp: %w", err)
 	}
 	return nil

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -41,7 +41,7 @@ func TestAppendLogWritesOneJSONLinePerCall(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open jsonl: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	lineCount := 0
@@ -103,7 +103,7 @@ func TestAppendLogMultipleEntries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open jsonl: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	lineCount := 0
@@ -170,7 +170,9 @@ func TestRewriteCardAtomicNoTmpArtifact(t *testing.T) {
 		Front: "Q\n",
 		Back:  "A\n",
 	}
-	os.WriteFile(cardPath, orig.Serialize(), 0o644)
+	if err := os.WriteFile(cardPath, orig.Serialize(), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
 
 	s := store.NewStore(t.TempDir(), "mydeck")
 	orig.State = "learning"
@@ -215,7 +217,9 @@ func TestPersistWritesLogBeforeFrontmatter(t *testing.T) {
 		Front: "Q\n",
 		Back:  "A\n",
 	}
-	os.WriteFile(cardPath, c.Serialize(), 0o644)
+	if err := os.WriteFile(cardPath, c.Serialize(), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
 
 	stateDir := t.TempDir()
 	s := store.NewStore(stateDir, "mydeck")

--- a/internal/tui/review.go
+++ b/internal/tui/review.go
@@ -1,11 +1,11 @@
 // Package tui implements the Bubble Tea review interface for spaced-repetition
 // cards. A review session follows a three-state lifecycle:
 //
-//   1. Front — the question side is displayed.
-//   2. Back — pressing Space or Enter reveals the answer and shows interval
-//      previews (again, hard, good, easy) computed by the scheduler.
-//   3. Rate — pressing a rating key (1–4) applies the score via RateFunc,
-//      advances to the next card, and returns to the front state.
+//  1. Front — the question side is displayed.
+//  2. Back — pressing Space or Enter reveals the answer and shows interval
+//     previews (again, hard, good, easy) computed by the scheduler.
+//  3. Rate — pressing a rating key (1–4) applies the score via RateFunc,
+//     advances to the next card, and returns to the front state.
 //
 // When every card has been rated the session ends and View signals completion.
 package tui
@@ -66,11 +66,11 @@ func (m ReviewModel) Init() tea.Cmd {
 
 // Update implements tea.Model. It handles the review lifecycle:
 //
-//   • Space / Enter — flip the current card to its back side and compute
+//   - Space / Enter — flip the current card to its back side and compute
 //     interval previews via the fsrs scheduler.
-//   • 1–4 — rate the card (only valid while the back is showing), advance
+//   - 1–4 — rate the card (only valid while the back is showing), advance
 //     to the next card, and clear previews.
-//   • q — emit tea.Quit to exit the application.
+//   - q — emit tea.Quit to exit the application.
 func (m ReviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -5,14 +5,18 @@ package version
 
 import "runtime/debug"
 
-var (
-	Version string
-	Commit  string
-	Date    string
-)
+// Version is the release version injected via ldflags at build time.
+var Version string
+
+// Commit is the Git commit hash injected via ldflags at build time.
+var Commit string
+
+// Date is the build timestamp injected via ldflags at build time.
+var Date string
 
 var readBuildInfo = debug.ReadBuildInfo
 
+// Info holds the resolved version metadata.
 type Info struct {
 	Version string `json:"version"`
 	Commit  string `json:"commit"`
@@ -20,6 +24,7 @@ type Info struct {
 	Source  string `json:"source"`
 }
 
+// Get resolves version metadata from ldflags, build info, or defaults.
 func Get() Info {
 	if Version != "" {
 		return Info{Version: Version, Commit: Commit, Date: Date, Source: "ldflags"}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,29 @@
+build:
+    go build -o ./bin/srs ./cmd/srs
+
+test:
+    go test ./...
+
+vet:
+    go vet ./...
+
+fmt:
+    gofmt -w .
+
+fmt-check:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    unformatted=$(gofmt -l .)
+    if [ -n "$unformatted" ]; then
+        echo "Unformatted files:"
+        echo "$unformatted"
+        exit 1
+    fi
+
+lint:
+    golangci-lint run
+
+ci: fmt-check lint vet test
+
+clean:
+    rm -rf ./bin


### PR DESCRIPTION
Closes #19

## Summary

- Adds `.golangci.yml` with version 2 schema, curated linter set (errcheck, govet, ineffassign, revive, staticcheck, unused), and gofmt formatter. Revive configured with only the `exported` rule.
- Adds `justfile` with recipes: `build`, `test`, `vet`, `fmt`, `fmt-check`, `lint`, `ci` (full local gate: fmt-check + lint + vet + test), `clean`.
- Fixes existing lint violations across the codebase so `just ci` passes cleanly.

## Acceptance criteria

- [x] `.golangci.yml` exists with v2 schema and curated linter set matching PRD spec
- [x] Revive configured with only the `exported` rule
- [x] gofmt formatter enabled
- [x] `justfile` exists with all recipes: `build`, `test`, `vet`, `fmt`, `fmt-check`, `lint`, `ci`, `clean`
- [x] `just ci` runs fmt-check + lint + vet + test and all pass on current codebase
- [x] `just build` compiles to `./bin/srs`