### PR TITLE
feat(card,deck,fsrs,store,tui): Add end-to-end cloze card support

### DIFF
--- a/internal/card/card.go
+++ b/internal/card/card.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -27,19 +28,31 @@ const (
 	Cloze Type = "cloze"
 )
 
+// ClozeGroup holds the FSRS scheduling state for a single cloze deletion
+// group (e.g. "c1", "c2").
+type ClozeGroup struct {
+	State      string  `yaml:"state,omitempty"`
+	Due        string  `yaml:"due,omitempty"`
+	Stability  float64 `yaml:"stability,omitempty"`
+	Difficulty float64 `yaml:"difficulty,omitempty"`
+	Reps       int     `yaml:"reps,omitempty"`
+	Lapses     int     `yaml:"lapses,omitempty"`
+}
+
 // Meta holds the YAML frontmatter for a card.
 type Meta struct {
-	Schema     int      `yaml:"schema"`
-	ID         string   `yaml:"id"`
-	Type       Type     `yaml:"type"`
-	Created    string   `yaml:"created"`
-	Tags       []string `yaml:"tags"`
-	State      string   `yaml:"state,omitempty"`
-	Due        string   `yaml:"due,omitempty"`
-	Stability  float64  `yaml:"stability,omitempty"`
-	Difficulty float64  `yaml:"difficulty,omitempty"`
-	Reps       int      `yaml:"reps,omitempty"`
-	Lapses     int      `yaml:"lapses,omitempty"`
+	Schema     int                   `yaml:"schema"`
+	ID         string                `yaml:"id"`
+	Type       Type                  `yaml:"type"`
+	Created    string                `yaml:"created"`
+	Tags       []string              `yaml:"tags"`
+	State      string                `yaml:"state,omitempty"`
+	Due        string                `yaml:"due,omitempty"`
+	Stability  float64               `yaml:"stability,omitempty"`
+	Difficulty float64               `yaml:"difficulty,omitempty"`
+	Reps       int                   `yaml:"reps,omitempty"`
+	Lapses     int                   `yaml:"lapses,omitempty"`
+	Clozes     map[string]ClozeGroup `yaml:"clozes,omitempty"`
 }
 
 // Card represents a spaced-repetition card backed by a Markdown file.
@@ -47,6 +60,7 @@ type Card struct {
 	Meta
 	Front    string
 	Back     string
+	Body     string // raw body for cloze cards (no Front/Back headings)
 	FilePath string
 }
 
@@ -98,30 +112,86 @@ func Parse(data []byte) (*Card, error) {
 		return nil, nil
 	}
 	front, back := splitBody(string(body))
-	return &Card{
+	c := &Card{
 		Meta:  *fm,
 		Front: front,
 		Back:  back,
-	}, nil
+	}
+	// For cloze cards (no Front/Back headings), capture the raw body.
+	if front == "" && back == "" && len(body) > 0 {
+		c.Body = strings.TrimSpace(string(body)) + "\n"
+	}
+	return c, nil
 }
 
-// Serialize writes the card back to its Markdown representation,
-// including YAML frontmatter and Front/Back sections.
+var clozePattern = regexp.MustCompile(`\{\{c(\d+)::([^}]+)\}\}`)
+
+// ExtractClozeGroups finds all unique cloze deletion groups (e.g. "c1", "c2")
+// in body and returns them sorted. Both {{cN::answer}} and
+// {{cN::answer::hint}} syntax are supported.
+func ExtractClozeGroups(body string) []string {
+	seen := make(map[string]bool)
+	matches := clozePattern.FindAllStringSubmatch(body, -1)
+	for _, m := range matches {
+		if len(m) >= 2 {
+			group := "c" + m[1]
+			seen[group] = true
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	groups := make([]string, 0, len(seen))
+	for g := range seen {
+		groups = append(groups, g)
+	}
+	sort.Strings(groups)
+	return groups
+}
+
+// Serialize writes the card back to its Markdown representation.
+// Basic cards include Front/Back sections; cloze cards write the raw body.
 func (c *Card) Serialize() []byte {
-	fmData, _ := yaml.Marshal(&c.Meta)
+	var fmData []byte
+	if c.Type == Cloze {
+		fmData, _ = yaml.Marshal(struct {
+			Schema  int                   `yaml:"schema"`
+			ID      string                `yaml:"id"`
+			Type    Type                  `yaml:"type"`
+			Created string                `yaml:"created"`
+			Tags    []string              `yaml:"tags"`
+			Clozes  map[string]ClozeGroup `yaml:"clozes,omitempty"`
+		}{
+			Schema:  c.Schema,
+			ID:      c.ID,
+			Type:    c.Type,
+			Created: c.Created,
+			Tags:    c.Tags,
+			Clozes:  c.Clozes,
+		})
+	} else {
+		fmData, _ = yaml.Marshal(&c.Meta)
+	}
 	var b strings.Builder
 	b.WriteString("---\n")
 	b.Write(fmData)
 	b.WriteString("---\n\n")
-	b.WriteString("## Front\n\n")
-	b.WriteString(c.Front)
-	if !strings.HasSuffix(c.Front, "\n") {
-		b.WriteByte('\n')
-	}
-	b.WriteString("## Back\n\n")
-	b.WriteString(c.Back)
-	if !strings.HasSuffix(c.Back, "\n") {
-		b.WriteByte('\n')
+	if c.Type == Cloze {
+		b.WriteString(c.Body)
+		if !strings.HasSuffix(c.Body, "\n") {
+			b.WriteByte('\n')
+		}
+	} else {
+		b.WriteString("## Front\n\n")
+		b.WriteString(c.Front)
+		if !strings.HasSuffix(c.Front, "\n") {
+			b.WriteByte('\n')
+		}
+		b.WriteString("## Back\n\n")
+		b.WriteString(c.Back)
+		if !strings.HasSuffix(c.Back, "\n") {
+			b.WriteByte('\n')
+		}
 	}
 	return []byte(b.String())
 }

--- a/internal/card/card_test.go
+++ b/internal/card/card_test.go
@@ -162,3 +162,181 @@ func TestRoundTripBasicCard(t *testing.T) {
 		t.Errorf("roundtrip Back = %q, want %q", parsed2.Back, c.Back)
 	}
 }
+
+// TestParseClozeCardCapturesBody verifies that a cloze card without ## Front/
+// ## Back headings has its body text captured in the Body field.
+func TestParseClozeCardCapturesBody(t *testing.T) {
+	got, err := card.ParseFile("testdata/cloze_single.md")
+	if err != nil {
+		t.Fatalf("ParseFile() error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("ParseFile() = nil, want card")
+	}
+	if got.Type != card.Cloze {
+		t.Errorf("Type = %v, want %v", got.Type, card.Cloze)
+	}
+	wantBody := "The capital of France is {{c1::Paris}}.\n"
+	if got.Body != wantBody {
+		t.Errorf("Body = %q, want %q", got.Body, wantBody)
+	}
+}
+
+// TestParseClozeCardWithGroups verifies that a cloze card with a clozes: map
+// in frontmatter parses each group's FSRS state correctly.
+func TestParseClozeCardWithGroups(t *testing.T) {
+	got, err := card.ParseFile("testdata/cloze_multi.md")
+	if err != nil {
+		t.Fatalf("ParseFile() error: %v", err)
+	}
+	if got == nil {
+		t.Fatal("ParseFile() = nil, want card")
+	}
+	if got.Type != card.Cloze {
+		t.Errorf("Type = %v, want %v", got.Type, card.Cloze)
+	}
+	if len(got.Clozes) != 2 {
+		t.Fatalf("len(Clozes) = %d, want 2", len(got.Clozes))
+	}
+	c1, ok := got.Clozes["c1"]
+	if !ok {
+		t.Fatal("missing c1 in Clozes")
+	}
+	if c1.State != "review" {
+		t.Errorf("c1.State = %q, want %q", c1.State, "review")
+	}
+	if c1.Due != "2026-02-15T10:30:00Z" {
+		t.Errorf("c1.Due = %q, want %q", c1.Due, "2026-02-15T10:30:00Z")
+	}
+	if c1.Stability != 12.5 {
+		t.Errorf("c1.Stability = %v, want %v", c1.Stability, 12.5)
+	}
+	if c1.Difficulty != 5.2 {
+		t.Errorf("c1.Difficulty = %v, want %v", c1.Difficulty, 5.2)
+	}
+	if c1.Reps != 4 {
+		t.Errorf("c1.Reps = %d, want %d", c1.Reps, 4)
+	}
+	if c1.Lapses != 1 {
+		t.Errorf("c1.Lapses = %d, want %d", c1.Lapses, 1)
+	}
+	c2, ok := got.Clozes["c2"]
+	if !ok {
+		t.Fatal("missing c2 in Clozes")
+	}
+	if c2.State != "learning" {
+		t.Errorf("c2.State = %q, want %q", c2.State, "learning")
+	}
+	if c2.Stability != 1.5 {
+		t.Errorf("c2.Stability = %v, want %v", c2.Stability, 1.5)
+	}
+}
+
+// TestRoundTripClozeCard checks that a cloze card's ID, Type, Body, and
+// per-group FSRS fields survive a Parse → Serialize → Parse round-trip.
+func TestRoundTripClozeCard(t *testing.T) {
+	original, err := os.ReadFile("testdata/cloze_multi.md")
+	if err != nil {
+		t.Fatalf("read testdata: %v", err)
+	}
+	c, err := card.Parse(original)
+	if err != nil {
+		t.Fatalf("Parse() error: %v", err)
+	}
+	serialized := c.Serialize()
+	parsed2, err := card.Parse(serialized)
+	if err != nil {
+		t.Fatalf("Parse(roundtrip) error: %v", err)
+	}
+	if parsed2.ID != c.ID {
+		t.Errorf("roundtrip ID = %q, want %q", parsed2.ID, c.ID)
+	}
+	if parsed2.Type != c.Type {
+		t.Errorf("roundtrip Type = %v, want %v", parsed2.Type, c.Type)
+	}
+	if parsed2.Body != c.Body {
+		t.Errorf("roundtrip Body = %q, want %q", parsed2.Body, c.Body)
+	}
+	if len(parsed2.Clozes) != len(c.Clozes) {
+		t.Fatalf("roundtrip len(Clozes) = %d, want %d", len(parsed2.Clozes), len(c.Clozes))
+	}
+	for key, want := range c.Clozes {
+		got, ok := parsed2.Clozes[key]
+		if !ok {
+			t.Errorf("roundtrip missing Clozes[%q]", key)
+			continue
+		}
+		if got.State != want.State {
+			t.Errorf("roundtrip Clozes[%q].State = %q, want %q", key, got.State, want.State)
+		}
+		if got.Due != want.Due {
+			t.Errorf("roundtrip Clozes[%q].Due = %q, want %q", key, got.Due, want.Due)
+		}
+		if got.Stability != want.Stability {
+			t.Errorf("roundtrip Clozes[%q].Stability = %v, want %v", key, got.Stability, want.Stability)
+		}
+		if got.Difficulty != want.Difficulty {
+			t.Errorf("roundtrip Clozes[%q].Difficulty = %v, want %v", key, got.Difficulty, want.Difficulty)
+		}
+		if got.Reps != want.Reps {
+			t.Errorf("roundtrip Clozes[%q].Reps = %d, want %d", key, got.Reps, want.Reps)
+		}
+		if got.Lapses != want.Lapses {
+			t.Errorf("roundtrip Clozes[%q].Lapses = %d, want %d", key, got.Lapses, want.Lapses)
+		}
+	}
+}
+
+// TestExtractClozeGroups finds all unique deletion groups in a body string.
+func TestExtractClozeGroups(t *testing.T) {
+	tests := []struct {
+		name  string
+		body  string
+		want  []string
+	}{
+		{
+			name: "single group",
+			body: "The capital of France is {{c1::Paris}}.",
+			want: []string{"c1"},
+		},
+		{
+			name: "multiple groups",
+			body: "{{c1::Paris}} is in {{c2::France}}.",
+			want: []string{"c1", "c2"},
+		},
+		{
+			name: "group with hint",
+			body: "The answer is {{c1::42::a number}}.",
+			want: []string{"c1"},
+		},
+		{
+			name: "duplicate groups deduplicated",
+			body: "{{c1::A}} and {{c1::B}} are both c1.",
+			want: []string{"c1"},
+		},
+		{
+			name: "no groups",
+			body: "Plain text without cloze.",
+			want: nil,
+		},
+		{
+			name: "mixed groups unordered",
+			body: "{{c2::second}} {{c1::first}}",
+			want: []string{"c1", "c2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := card.ExtractClozeGroups(tt.body)
+			if len(got) != len(tt.want) {
+				t.Errorf("ExtractClozeGroups() = %v, want %v", got, tt.want)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("ExtractClozeGroups()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/card/serialize_test.go
+++ b/internal/card/serialize_test.go
@@ -1,0 +1,76 @@
+package card_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jvcorredor/srs-tui/internal/card"
+)
+
+func TestClozeSerializeOmitsFlatFields(t *testing.T) {
+	c := &card.Card{
+		Meta: card.Meta{
+			Schema:  1,
+			ID:      "test-id",
+			Type:    card.Cloze,
+			Created: "2026-01-01T00:00:00Z",
+			Clozes: map[string]card.ClozeGroup{
+				"c1": {State: "new"},
+			},
+		},
+		Body: "{{c1::A}}\n",
+	}
+	out := string(c.Serialize())
+	if strings.Contains(out, "clozes:") {
+		// Extract frontmatter only
+		lines := strings.Split(out, "\n")
+		inFM := false
+		var fmLines []string
+		for _, line := range lines {
+			if line == "---" {
+				if !inFM {
+					inFM = true
+					continue
+				} else {
+					break
+				}
+			}
+			if inFM {
+				fmLines = append(fmLines, line)
+			}
+		}
+		for _, flatField := range []string{"state:", "due:", "stability:", "difficulty:", "reps:", "lapses:"} {
+			// Check for top-level flat field (line starts with field name, not indented)
+			for _, line := range fmLines {
+				if strings.HasPrefix(line, flatField) {
+					t.Errorf("cloze frontmatter should not contain top-level flat field %q, got line: %s", flatField, line)
+				}
+			}
+		}
+	} else {
+		t.Errorf("cloze serialization should contain clozes: map, got:\n%s", out)
+	}
+}
+
+func TestBasicSerializeIncludesFlatFields(t *testing.T) {
+	c := &card.Card{
+		Meta: card.Meta{
+			Schema:  1,
+			ID:      "test-id",
+			Type:    card.Basic,
+			Created: "2026-01-01T00:00:00Z",
+			State:   "review",
+			Due:     "2026-02-01T00:00:00Z",
+			Stability: 5.0,
+		},
+		Front: "Q\n",
+		Back:  "A\n",
+	}
+	out := string(c.Serialize())
+	if !strings.Contains(out, "state: review") {
+		t.Errorf("basic serialization should contain flat state field, got:\n%s", out)
+	}
+	if strings.Contains(out, "clozes:") {
+		t.Errorf("basic serialization should not contain clozes: map, got:\n%s", out)
+	}
+}

--- a/internal/card/testdata/cloze_multi.md
+++ b/internal/card/testdata/cloze_multi.md
@@ -1,0 +1,24 @@
+---
+schema: 1
+id: 01923f44-5a06-7d2e-8c9f-1b2d3e4f5a6d
+type: cloze
+created: 2026-01-15T10:30:00Z
+tags: [history]
+clozes:
+  c1:
+    state: review
+    due: 2026-02-15T10:30:00Z
+    stability: 12.5
+    difficulty: 5.2
+    reps: 4
+    lapses: 1
+  c2:
+    state: learning
+    due: 2026-01-16T10:30:00Z
+    stability: 1.5
+    difficulty: 7.0
+    reps: 2
+    lapses: 0
+---
+
+{{c1::George Washington}} was the first president of the {{c2::United States}}.

--- a/internal/card/testdata/cloze_single.md
+++ b/internal/card/testdata/cloze_single.md
@@ -1,0 +1,9 @@
+---
+schema: 1
+id: 01923f44-5a06-7d2e-8c9f-1b2d3e4f5a6c
+type: cloze
+created: 2026-01-15T10:30:00Z
+tags: [geography]
+---
+
+The capital of France is {{c1::Paris}}.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -79,18 +79,33 @@ func defaultEditorRun(file string) error {
 	return cmd.Run()
 }
 
-// MakeRateFunc builds a tui.RateFunc that rates a card using the FSRS algorithm,
-// persists the resulting state to the store's JSONL log and the card's Markdown
-// file, and returns the next state together with interval previews.
+// MakeRateFunc builds a tui.RateFunc that rates a review item using the FSRS
+// algorithm, persists the resulting state to the store's JSONL log and the
+// card's Markdown file, and returns the next state together with interval
+// previews. For cloze cards, only the active group's state is updated.
 func MakeRateFunc(s *store.Store) tui.RateFunc {
-	return func(c *card.Card, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, error) {
-		prevState := fsrs.CardState{
-			State:      fsrs.NormalizeState(c.State),
-			Due:        fsrs.ParseTime(c.Due),
-			Stability:  c.Stability,
-			Difficulty: c.Difficulty,
-			Reps:       c.Reps,
-			Lapses:     c.Lapses,
+	return func(it *deck.ReviewItem, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, error) {
+		var prevState fsrs.CardState
+		if it.Card.Type == card.Cloze && it.ClozeGroup != "" {
+			if g, ok := it.Card.Clozes[it.ClozeGroup]; ok {
+				prevState = fsrs.CardState{
+					State:      fsrs.NormalizeState(g.State),
+					Due:        fsrs.ParseTime(g.Due),
+					Stability:  g.Stability,
+					Difficulty: g.Difficulty,
+					Reps:       g.Reps,
+					Lapses:     g.Lapses,
+				}
+			}
+		} else {
+			prevState = fsrs.CardState{
+				State:      fsrs.NormalizeState(it.Card.State),
+				Due:        fsrs.ParseTime(it.Card.Due),
+				Stability:  it.Card.Stability,
+				Difficulty: it.Card.Difficulty,
+				Reps:       it.Card.Reps,
+				Lapses:     it.Card.Lapses,
+			}
 		}
 
 		nextState, previews, err := fsrs.Rate(prevState, rating, now)
@@ -98,25 +113,39 @@ func MakeRateFunc(s *store.Store) tui.RateFunc {
 			return fsrs.CardState{}, nil, err
 		}
 
-		store.EnsureID(c)
+		store.EnsureID(it.Card)
 
 		entry := store.LogEntry{
 			Schema: 1,
 			TS:     now,
-			CardID: c.ID,
+			CardID: it.Card.ID,
 			Rating: rating,
 			Prev:   prevState,
 			Next:   nextState,
 		}
+		if it.ClozeGroup != "" {
+			entry.ClozeGroup = &it.ClozeGroup
+		}
 
-		c.State = string(nextState.State)
-		c.Due = nextState.Due.Format(time.RFC3339)
-		c.Stability = nextState.Stability
-		c.Difficulty = nextState.Difficulty
-		c.Reps = nextState.Reps
-		c.Lapses = nextState.Lapses
+		if it.Card.Type == card.Cloze && it.ClozeGroup != "" {
+			g := it.Card.Clozes[it.ClozeGroup]
+			g.State = string(nextState.State)
+			g.Due = nextState.Due.Format(time.RFC3339)
+			g.Stability = nextState.Stability
+			g.Difficulty = nextState.Difficulty
+			g.Reps = nextState.Reps
+			g.Lapses = nextState.Lapses
+			it.Card.Clozes[it.ClozeGroup] = g
+		} else {
+			it.Card.State = string(nextState.State)
+			it.Card.Due = nextState.Due.Format(time.RFC3339)
+			it.Card.Stability = nextState.Stability
+			it.Card.Difficulty = nextState.Difficulty
+			it.Card.Reps = nextState.Reps
+			it.Card.Lapses = nextState.Lapses
+		}
 
-		if err := s.Persist(entry, c.FilePath, c); err != nil {
+		if err := s.Persist(entry, it.Card.FilePath, it.Card); err != nil {
 			return nextState, previews, fmt.Errorf("persist: %w", err)
 		}
 
@@ -127,7 +156,7 @@ func MakeRateFunc(s *store.Store) tui.RateFunc {
 // defaultReviewRun builds the review queue for deckDir, opens the interactive
 // Bubble Tea review session, and persists ratings via MakeRateFunc.
 func defaultReviewRun(deckDir string) error {
-	cards, err := deck.BuildQueue(deckDir)
+	items, err := deck.BuildQueue(deckDir)
 	if err != nil {
 		return fmt.Errorf("review: %w", err)
 	}
@@ -137,7 +166,7 @@ func defaultReviewRun(deckDir string) error {
 	s := store.NewStore(stateDir, deckSlug)
 	rateFunc := MakeRateFunc(s)
 
-	m := tui.NewReviewModel(cards, rateFunc)
+	m := tui.NewReviewModel(items, rateFunc)
 	p := tea.NewProgram(m, tea.WithAltScreen())
 	_, err = p.Run()
 	return err

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/jvcorredor/srs-tui/internal/card"
 	"github.com/jvcorredor/srs-tui/internal/cli"
+	"github.com/jvcorredor/srs-tui/internal/deck"
 	"github.com/jvcorredor/srs-tui/internal/fsrs"
 	"github.com/jvcorredor/srs-tui/internal/store"
 	"github.com/jvcorredor/srs-tui/internal/version"
@@ -159,7 +160,7 @@ func TestMakeRateFuncPersistsRating(t *testing.T) {
 	rateFunc := cli.MakeRateFunc(s)
 
 	now := time.Now()
-	nextState, previews, err := rateFunc(c, 3, now)
+	nextState, previews, err := rateFunc(&deck.ReviewItem{Card: c}, 3, now)
 	if err != nil {
 		t.Fatalf("rateFunc() error: %v", err)
 	}
@@ -208,6 +209,85 @@ func TestMakeRateFuncPersistsRating(t *testing.T) {
 	}
 	if parsed.Stability <= 0 {
 		t.Error("card stability should be positive after rating")
+	}
+}
+
+// TestMakeRateFuncUpdatesOnlyActiveClozeGroup verifies that rating a cloze card
+// updates only the active group's FSRS state, leaves other groups untouched,
+// writes a JSONL log entry with the cloze_group field, and persists the card
+// with per-group frontmatter.
+func TestMakeRateFuncUpdatesOnlyActiveClozeGroup(t *testing.T) {
+	cardDir := t.TempDir()
+	stateDir := t.TempDir()
+
+	c := &card.Card{
+		Meta: card.Meta{
+			Schema: 1,
+			ID:     "cloze-1",
+			Type:   card.Cloze,
+			Clozes: map[string]card.ClozeGroup{
+				"c1": {State: "new"},
+				"c2": {State: "new"},
+			},
+		},
+		Body:     "{{c1::A}} and {{c2::B}}\n",
+		FilePath: filepath.Join(cardDir, "cloze-1.md"),
+	}
+	os.WriteFile(c.FilePath, c.Serialize(), 0o644)
+
+	s := store.NewStore(stateDir, "testdeck")
+	rateFunc := cli.MakeRateFunc(s)
+
+	now := time.Now()
+	item := &deck.ReviewItem{Card: c, ClozeGroup: "c1"}
+	nextState, _, err := rateFunc(item, 3, now)
+	if err != nil {
+		t.Fatalf("rateFunc() error: %v", err)
+	}
+
+	// c1 should be updated, c2 should remain "new"
+	if c.Clozes["c1"].State == "" || c.Clozes["c1"].State == "new" {
+		t.Errorf("c1 state should be updated, got %q", c.Clozes["c1"].State)
+	}
+	if c.Clozes["c2"].State != "new" {
+		t.Errorf("c2 state should remain 'new', got %q", c.Clozes["c2"].State)
+	}
+	if c.Clozes["c2"].Stability != 0 {
+		t.Errorf("c2 stability should remain 0, got %v", c.Clozes["c2"].Stability)
+	}
+
+	// Log should contain cloze_group "c1"
+	logPath := filepath.Join(stateDir, "testdeck.jsonl")
+	f, err := os.Open(logPath)
+	if err != nil {
+		t.Fatalf("open jsonl: %v", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var entry store.LogEntry
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if entry.ClozeGroup == nil || *entry.ClozeGroup != "c1" {
+			t.Errorf("cloze_group = %v, want %q", entry.ClozeGroup, "c1")
+		}
+		if entry.Next.State != nextState.State {
+			t.Errorf("next.state = %q, want %q", entry.Next.State, nextState.State)
+		}
+	}
+
+	// Card file should persist the per-group frontmatter
+	parsed, err := card.ParseFile(c.FilePath)
+	if err != nil {
+		t.Fatalf("ParseFile after rate: %v", err)
+	}
+	if parsed.Clozes["c1"].State != c.Clozes["c1"].State {
+		t.Errorf("roundtrip c1 state = %q, want %q", parsed.Clozes["c1"].State, c.Clozes["c1"].State)
+	}
+	if parsed.Clozes["c2"].State != "new" {
+		t.Errorf("roundtrip c2 state = %q, want %q", parsed.Clozes["c2"].State, "new")
 	}
 }
 
@@ -439,7 +519,7 @@ func TestMakeRateFuncAssignsID(t *testing.T) {
 	s := store.NewStore(stateDir, "testdeck")
 	rateFunc := cli.MakeRateFunc(s)
 
-	_, _, err := rateFunc(c, 3, time.Now())
+	_, _, err := rateFunc(&deck.ReviewItem{Card: c}, 3, time.Now())
 	if err != nil {
 		t.Fatalf("rateFunc() error: %v", err)
 	}

--- a/internal/deck/deck.go
+++ b/internal/deck/deck.go
@@ -10,6 +10,13 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/card"
 )
 
+// ReviewItem represents a single unit of review: a card and, for cloze cards,
+// the specific deletion group being reviewed. Basic cards have an empty ClozeGroup.
+type ReviewItem struct {
+	Card       *card.Card
+	ClozeGroup string
+}
+
 // Discover returns the absolute paths of every immediate subdirectory inside
 // root. Only directories are returned; regular files are ignored. Symlinks to
 // directories are followed.
@@ -33,10 +40,11 @@ func Discover(root string) ([]string, error) {
 }
 
 // BuildQueue walks deckDir recursively, parses every .md file into a Card,
-// and returns the collected cards in random order. Files that cannot be
-// parsed as cards or that lack frontmatter are skipped.
-func BuildQueue(deckDir string) ([]*card.Card, error) {
-	var cards []*card.Card
+// and returns review items in random order. Basic cards produce a single item;
+// cloze cards produce one item per unique cloze group found in the body.
+// Files that cannot be parsed as cards or that lack frontmatter are skipped.
+func BuildQueue(deckDir string) ([]ReviewItem, error) {
+	var items []ReviewItem
 	err := filepath.WalkDir(deckDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -54,14 +62,26 @@ func BuildQueue(deckDir string) ([]*card.Card, error) {
 		if c == nil {
 			return nil
 		}
-		cards = append(cards, c)
+		if c.Type == card.Cloze {
+			groups := card.ExtractClozeGroups(c.Body)
+			if len(groups) == 0 {
+				// No cloze markers found; enqueue as a single item.
+				items = append(items, ReviewItem{Card: c})
+			} else {
+				for _, g := range groups {
+					items = append(items, ReviewItem{Card: c, ClozeGroup: g})
+				}
+			}
+		} else {
+			items = append(items, ReviewItem{Card: c})
+		}
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
-	rand.Shuffle(len(cards), func(i, j int) {
-		cards[i], cards[j] = cards[j], cards[i]
+	rand.Shuffle(len(items), func(i, j int) {
+		items[i], items[j] = items[j], items[i]
 	})
-	return cards, nil
+	return items, nil
 }

--- a/internal/deck/deck_test.go
+++ b/internal/deck/deck_test.go
@@ -32,6 +32,25 @@ func writeBasicCard(t *testing.T, dir, id, front, back string) {
 	}
 }
 
+// writeClozeCard creates a cloze card file in dir named id+".md".
+func writeClozeCard(t *testing.T, dir, id, body string, clozes map[string]card.ClozeGroup) {
+	t.Helper()
+	c := &card.Card{
+		Meta: card.Meta{
+			Schema:  1,
+			ID:      id,
+			Type:    card.Cloze,
+			Created: "2026-01-01T00:00:00Z",
+			Clozes:  clozes,
+		},
+		Body: body + "\n",
+	}
+	err := os.WriteFile(filepath.Join(dir, id+".md"), c.Serialize(), 0o644)
+	if err != nil {
+		t.Fatalf("write cloze card: %v", err)
+	}
+}
+
 // TestDiscoverDecks verifies that Discover returns only immediate
 // subdirectories and ignores regular files.
 func TestDiscoverDecks(t *testing.T) {
@@ -110,8 +129,8 @@ func TestQueueContainsAllCardsShuffled(t *testing.T) {
 	}
 
 	ids := make(map[string]bool)
-	for _, c := range q {
-		ids[c.ID] = true
+	for _, it := range q {
+		ids[it.Card.ID] = true
 	}
 	for _, want := range []string{"id-1", "id-2", "id-3"} {
 		if !ids[want] {
@@ -137,7 +156,49 @@ func TestQueueSkipsNonCardFiles(t *testing.T) {
 	if len(q) != 1 {
 		t.Fatalf("queue length = %d, want 1 (non-card files skipped)", len(q))
 	}
-	if q[0].ID != "id-1" {
-		t.Errorf("queue[0].ID = %q, want %q", q[0].ID, "id-1")
+	if q[0].Card.ID != "id-1" {
+		t.Errorf("queue[0].Card.ID = %q, want %q", q[0].Card.ID, "id-1")
+	}
+}
+
+// TestQueueEnumeratesClozeGroups checks that a cloze card produces one
+// ReviewItem per unique cloze group, while basic cards produce a single item.
+func TestQueueEnumeratesClozeGroups(t *testing.T) {
+	root := t.TempDir()
+	deckDir := filepath.Join(root, "mydeck")
+	os.MkdirAll(deckDir, 0o755)
+
+	writeBasicCard(t, deckDir, "basic-1", "Q1", "A1")
+	writeClozeCard(t, deckDir, "cloze-1", "{{c1::A}} and {{c2::B}}", nil)
+
+	q, err := deck.BuildQueue(deckDir)
+	if err != nil {
+		t.Fatalf("BuildQueue() error: %v", err)
+	}
+	if len(q) != 3 {
+		t.Fatalf("queue length = %d, want 3 (1 basic + 2 cloze groups)", len(q))
+	}
+
+	// Find items by card ID + group
+	items := make(map[string]string) // cardID -> clozeGroup
+	for _, it := range q {
+		key := it.Card.ID
+		if it.ClozeGroup != "" {
+			key += "/" + it.ClozeGroup
+		}
+		items[key] = it.ClozeGroup
+	}
+
+	if _, ok := items["basic-1"]; !ok {
+		t.Errorf("missing basic card in queue")
+	}
+	if items["basic-1"] != "" {
+		t.Errorf("basic card should have empty ClozeGroup, got %q", items["basic-1"])
+	}
+	if _, ok := items["cloze-1/c1"]; !ok {
+		t.Errorf("missing cloze-1/c1 in queue")
+	}
+	if _, ok := items["cloze-1/c2"]; !ok {
+		t.Errorf("missing cloze-1/c2 in queue")
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -20,9 +20,10 @@ type LogEntry struct {
 	Schema int       `json:"schema"`
 	TS     time.Time `json:"ts"`
 	CardID string    `json:"card_id"`
-	// ClozeGroup is reserved for future cloze-deletion grouping; currently unused.
-	ClozeGroup *int `json:"cloze_group,omitempty"`
-	Rating     int  `json:"rating"`
+	// ClozeGroup is the cloze deletion group key (e.g. "c1") when reviewing a
+	// cloze card; nil for basic cards.
+	ClozeGroup *string `json:"cloze_group,omitempty"`
+	Rating     int     `json:"rating"`
 	// DurationMs is reserved for future review-duration tracking; currently unused.
 	DurationMs int64          `json:"duration_ms"`
 	Prev       fsrs.CardState `json:"prev"`

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -125,7 +125,7 @@ func TestAppendLogIncludesClozeGroupWhenSet(t *testing.T) {
 	dir := t.TempDir()
 	s := store.NewStore(dir, "mydeck")
 
-	clozeGroup := 2
+	clozeGroup := "c1"
 	entry := store.LogEntry{
 		Schema:     1,
 		TS:         time.Now().UTC().Truncate(time.Millisecond),
@@ -151,7 +151,7 @@ func TestAppendLogIncludesClozeGroupWhenSet(t *testing.T) {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if got.ClozeGroup == nil || *got.ClozeGroup != clozeGroup {
-		t.Errorf("cloze_group = %v, want %d", got.ClozeGroup, clozeGroup)
+		t.Errorf("cloze_group = %v, want %q", got.ClozeGroup, clozeGroup)
 	}
 }
 

--- a/internal/tui/review.go
+++ b/internal/tui/review.go
@@ -12,23 +12,26 @@ package tui
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/glamour"
 	"github.com/jvcorredor/srs-tui/internal/card"
+	"github.com/jvcorredor/srs-tui/internal/deck"
 	"github.com/jvcorredor/srs-tui/internal/fsrs"
 )
 
-// RateFunc applies a user rating to a card and returns the resulting state,
-// interval previews for all possible ratings, and any error.
-type RateFunc func(c *card.Card, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, error)
+// RateFunc applies a user rating to a review item and returns the resulting
+// state, interval previews for all possible ratings, and any error.
+type RateFunc func(item *deck.ReviewItem, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, error)
 
 // ReviewModel is a Bubble Tea model that drives a flash-card review session.
-// It manages a deck of cards, tracks which side is visible, and coordinates
-// with a RateFunc to schedule cards after each rating.
+// It manages a deck of review items, tracks which side is visible, and
+// coordinates with a RateFunc to schedule cards after each rating.
 type ReviewModel struct {
-	cards       []*card.Card
+	items       []deck.ReviewItem
 	index       int
 	showingBack bool
 	renderer    *glamour.TermRenderer
@@ -37,13 +40,13 @@ type ReviewModel struct {
 	done        bool
 }
 
-// NewReviewModel creates a ReviewModel for the given cards. The rateFunc is
-// invoked each time the user presses a rating key (1–4) while the back side
-// is visible.
-func NewReviewModel(cards []*card.Card, rateFunc RateFunc) ReviewModel {
+// NewReviewModel creates a ReviewModel for the given review items. The
+// rateFunc is invoked each time the user presses a rating key (1–4) while
+// the back side is visible.
+func NewReviewModel(items []deck.ReviewItem, rateFunc RateFunc) ReviewModel {
 	r, _ := glamour.NewTermRenderer(glamour.WithStandardStyle("dark"))
 	return ReviewModel{
-		cards:    cards,
+		items:    items,
 		renderer: r,
 		rateFunc: rateFunc,
 	}
@@ -84,9 +87,9 @@ func (m ReviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.KeySpace, tea.KeyEnter:
 			if !m.showingBack {
 				m.showingBack = true
-				if m.index < len(m.cards) {
-					c := m.cards[m.index]
-					cs := cardStateFromCard(c)
+				if m.index < len(m.items) {
+					it := &m.items[m.index]
+					cs := cardStateFromItem(it)
 					m.previews = fsrs.Preview(cs, time.Now())
 				}
 			}
@@ -94,15 +97,15 @@ func (m ReviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		switch msg.String() {
 		case "1", "2", "3", "4":
-			if m.showingBack && m.rateFunc != nil && m.index < len(m.cards) {
+			if m.showingBack && m.rateFunc != nil && m.index < len(m.items) {
 				rating := int(msg.String()[0] - '0')
-				c := m.cards[m.index]
-				_, _, err := m.rateFunc(c, rating, time.Now())
+				it := &m.items[m.index]
+				_, _, err := m.rateFunc(it, rating, time.Now())
 				if err == nil {
 					m.index++
 					m.showingBack = false
 					m.previews = nil
-					if m.index >= len(m.cards) {
+					if m.index >= len(m.items) {
 						m.done = true
 					}
 				}
@@ -117,16 +120,21 @@ func (m ReviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 // card (markdown formatted via glamour) and, when the back is showing,
 // appends the interval previews returned by the scheduler.
 func (m ReviewModel) View() string {
-	if len(m.cards) == 0 {
+	if len(m.items) == 0 {
 		return "No cards in this deck.\nPress q to quit."
 	}
 	if m.done {
 		return "Session complete!\nPress q to quit."
 	}
-	c := m.cards[m.index]
-	content := c.Front
-	if m.showingBack {
-		content = c.Back
+	it := &m.items[m.index]
+	var content string
+	if it.Card.Type == card.Cloze {
+		content = renderCloze(it.Card.Body, it.ClozeGroup, m.showingBack)
+	} else {
+		content = it.Card.Front
+		if m.showingBack {
+			content = it.Card.Back
+		}
 	}
 	rendered, _ := m.renderer.Render(content)
 	if m.showingBack && len(m.previews) > 0 {
@@ -135,17 +143,60 @@ func (m ReviewModel) View() string {
 	return rendered
 }
 
-// cardStateFromCard converts a card.Card into the fsrs.CardState used by the
-// scheduler.
-func cardStateFromCard(c *card.Card) fsrs.CardState {
-	return fsrs.CardState{
-		State:      fsrs.NormalizeState(c.State),
-		Due:        fsrs.ParseTime(c.Due),
-		Stability:  c.Stability,
-		Difficulty: c.Difficulty,
-		Reps:       c.Reps,
-		Lapses:     c.Lapses,
+// cardStateFromItem extracts the FSRS state from a review item. For cloze
+// cards it uses the per-group state; for basic cards it uses the flat fields.
+func cardStateFromItem(it *deck.ReviewItem) fsrs.CardState {
+	if it.Card.Type == card.Cloze && it.ClozeGroup != "" {
+		if g, ok := it.Card.Clozes[it.ClozeGroup]; ok {
+			return fsrs.CardState{
+				State:      fsrs.NormalizeState(g.State),
+				Due:        fsrs.ParseTime(g.Due),
+				Stability:  g.Stability,
+				Difficulty: g.Difficulty,
+				Reps:       g.Reps,
+				Lapses:     g.Lapses,
+			}
+		}
 	}
+	return fsrs.CardState{
+		State:      fsrs.NormalizeState(it.Card.State),
+		Due:        fsrs.ParseTime(it.Card.Due),
+		Stability:  it.Card.Stability,
+		Difficulty: it.Card.Difficulty,
+		Reps:       it.Card.Reps,
+		Lapses:     it.Card.Lapses,
+	}
+}
+
+var renderClozeRe = regexp.MustCompile(`\{\{c(\d+)::([^}]+)\}\}`)
+
+// renderCloze processes a cloze card body for display. If activeGroup is set
+// and showAnswer is false, that group's deletions are replaced with a
+// placeholder ([...] or [hint] if present). All other deletions are revealed.
+func renderCloze(body, activeGroup string, showAnswer bool) string {
+	return renderClozeRe.ReplaceAllStringFunc(body, func(match string) string {
+		parts := renderClozeRe.FindStringSubmatch(match)
+		if len(parts) < 3 {
+			return match
+		}
+		group := "c" + parts[1]
+		inner := parts[2]
+		// inner may be "answer" or "answer::hint"
+		var answer, hint string
+		if i := strings.Index(inner, "::"); i >= 0 {
+			answer = inner[:i]
+			hint = inner[i+2:]
+		} else {
+			answer = inner
+		}
+		if showAnswer || group != activeGroup {
+			return answer
+		}
+		if hint != "" {
+			return "[" + hint + "]"
+		}
+		return "[...]"
+	})
 }
 
 // formatPreviews renders a list of interval previews as rating labels with

--- a/internal/tui/review_test.go
+++ b/internal/tui/review_test.go
@@ -12,6 +12,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/jvcorredor/srs-tui/internal/card"
+	"github.com/jvcorredor/srs-tui/internal/deck"
 	"github.com/jvcorredor/srs-tui/internal/fsrs"
 	"github.com/jvcorredor/srs-tui/internal/tui"
 )
@@ -22,13 +23,26 @@ func asReview(m tea.Model) tui.ReviewModel {
 	return m.(tui.ReviewModel)
 }
 
+// basicItem is a helper that builds a single basic ReviewItem for tests.
+func basicItem(id, front, back string) deck.ReviewItem {
+	return deck.ReviewItem{
+		Card: &card.Card{Meta: card.Meta{ID: id, Type: card.Basic}, Front: front, Back: back},
+	}
+}
+
+// clozeItem is a helper that builds a cloze ReviewItem for tests.
+func clozeItem(id, body, group string) deck.ReviewItem {
+	return deck.ReviewItem{
+		Card:       &card.Card{Meta: card.Meta{ID: id, Type: card.Cloze}, Body: body},
+		ClozeGroup: group,
+	}
+}
+
 // TestReviewFlipOnSpace verifies that pressing Space reveals the back of the
 // current card.
 func TestReviewFlipOnSpace(t *testing.T) {
-	cards := []*card.Card{
-		{Meta: card.Meta{ID: "1", Type: card.Basic}, Front: "Q", Back: "A"},
-	}
-	m := tui.NewReviewModel(cards, nil)
+	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
+	m := tui.NewReviewModel(items, nil)
 	if m.ShowingBack() {
 		t.Error("should start showing front")
 	}
@@ -40,10 +54,8 @@ func TestReviewFlipOnSpace(t *testing.T) {
 
 // TestReviewFlipOnEnter verifies that pressing Enter also reveals the back.
 func TestReviewFlipOnEnter(t *testing.T) {
-	cards := []*card.Card{
-		{Meta: card.Meta{ID: "1", Type: card.Basic}, Front: "Q", Back: "A"},
-	}
-	m := tui.NewReviewModel(cards, nil)
+	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
+	m := tui.NewReviewModel(items, nil)
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	if !asReview(updated).ShowingBack() {
 		t.Error("enter should flip to back")
@@ -52,10 +64,8 @@ func TestReviewFlipOnEnter(t *testing.T) {
 
 // TestReviewQuitOnQ verifies that pressing 'q' returns a tea.Quit command.
 func TestReviewQuitOnQ(t *testing.T) {
-	cards := []*card.Card{
-		{Meta: card.Meta{ID: "1", Type: card.Basic}, Front: "Q", Back: "A"},
-	}
-	m := tui.NewReviewModel(cards, nil)
+	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
+	m := tui.NewReviewModel(items, nil)
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
 	if cmd == nil {
 		t.Error("q should trigger quit")
@@ -65,10 +75,8 @@ func TestReviewQuitOnQ(t *testing.T) {
 // TestReviewQuitOnQWhenDone verifies that pressing 'q' quits even after the
 // session is complete (m.done == true).
 func TestReviewQuitOnQWhenDone(t *testing.T) {
-	cards := []*card.Card{
-		{Meta: card.Meta{ID: "1", Type: card.Basic}, Front: "Q", Back: "A"},
-	}
-	m := tui.NewReviewModel(cards, fakeRateFunc)
+	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
+	m := tui.NewReviewModel(items, fakeRateFunc)
 	// Flip and rate the only card so the session ends.
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
 	m = asReview(updated)
@@ -87,7 +95,7 @@ func TestReviewQuitOnQWhenDone(t *testing.T) {
 
 // fakeRateFunc is a stub RateFunc that returns fixed interval previews for
 // every rating, making tests deterministic and fast.
-func fakeRateFunc(c *card.Card, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, error) {
+func fakeRateFunc(item *deck.ReviewItem, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, error) {
 	next := fsrs.CardState{State: fsrs.StateLearning, Stability: 1.5}
 	previews := []fsrs.IntervalPreview{
 		{Rating: 1, State: fsrs.StateLearning, Interval: 1 * time.Minute},
@@ -101,11 +109,11 @@ func fakeRateFunc(c *card.Card, rating int, now time.Time) (fsrs.CardState, []fs
 // TestRatingKeyAdvancesCard checks that rating a flipped card moves the
 // session to the next card and resets the view to the front side.
 func TestRatingKeyAdvancesCard(t *testing.T) {
-	cards := []*card.Card{
-		{Meta: card.Meta{ID: "1", Type: card.Basic}, Front: "Q1", Back: "A1"},
-		{Meta: card.Meta{ID: "2", Type: card.Basic}, Front: "Q2", Back: "A2"},
+	items := []deck.ReviewItem{
+		basicItem("1", "Q1", "A1"),
+		basicItem("2", "Q2", "A2"),
 	}
-	m := tui.NewReviewModel(cards, fakeRateFunc)
+	m := tui.NewReviewModel(items, fakeRateFunc)
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
 	m = asReview(updated)
 
@@ -122,10 +130,8 @@ func TestRatingKeyAdvancesCard(t *testing.T) {
 // TestRatingKeyShowsIntervalPreviewsOnBack confirms that the rendered view
 // includes preview labels (Again, Hard, etc.) once the card is flipped.
 func TestRatingKeyShowsIntervalPreviewsOnBack(t *testing.T) {
-	cards := []*card.Card{
-		{Meta: card.Meta{ID: "1", Type: card.Basic}, Front: "Q", Back: "A"},
-	}
-	m := tui.NewReviewModel(cards, fakeRateFunc)
+	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
+	m := tui.NewReviewModel(items, fakeRateFunc)
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
 	m = asReview(updated)
 
@@ -138,13 +144,13 @@ func TestRatingKeyShowsIntervalPreviewsOnBack(t *testing.T) {
 // TestAllFourRatingKeysAccepted validates that every rating key (1–4) can be
 // used to advance through a multi-card session without error.
 func TestAllFourRatingKeysAccepted(t *testing.T) {
-	cards := []*card.Card{
-		{Meta: card.Meta{ID: "1", Type: card.Basic}, Front: "Q1", Back: "A1"},
-		{Meta: card.Meta{ID: "2", Type: card.Basic}, Front: "Q2", Back: "A2"},
-		{Meta: card.Meta{ID: "3", Type: card.Basic}, Front: "Q3", Back: "A3"},
-		{Meta: card.Meta{ID: "4", Type: card.Basic}, Front: "Q4", Back: "A4"},
+	items := []deck.ReviewItem{
+		basicItem("1", "Q1", "A1"),
+		basicItem("2", "Q2", "A2"),
+		basicItem("3", "Q3", "A3"),
+		basicItem("4", "Q4", "A4"),
 	}
-	m := tui.NewReviewModel(cards, fakeRateFunc)
+	m := tui.NewReviewModel(items, fakeRateFunc)
 
 	for _, key := range []rune{'1', '2', '3', '4'} {
 		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
@@ -154,5 +160,61 @@ func TestAllFourRatingKeysAccepted(t *testing.T) {
 	}
 	if m.CurrentIndex() != 4 {
 		t.Errorf("after rating 4 cards, index = %d, want 4", m.CurrentIndex())
+	}
+}
+
+// TestClozeQuestionHidesActiveGroup verifies that the question side of a cloze
+// card replaces the active group's deletions with a placeholder.
+func TestClozeQuestionHidesActiveGroup(t *testing.T) {
+	items := []deck.ReviewItem{
+		clozeItem("1", "The {{c1::capital::city}} of France is {{c2::Paris}}.", "c1"),
+	}
+	m := tui.NewReviewModel(items, nil)
+	view := m.View()
+	if strings.Contains(view, "capital") {
+		t.Errorf("question should hide active group c1, got:\n%s", view)
+	}
+	if !strings.Contains(view, "city") {
+		t.Errorf("question should show hint placeholder containing 'city', got:\n%s", view)
+	}
+	if !strings.Contains(view, "Paris") {
+		t.Errorf("question should reveal inactive group c2, got:\n%s", view)
+	}
+}
+
+// TestClozeAnswerRevealsActiveGroup verifies that the answer side of a cloze
+// card reveals all deletions including the active group.
+func TestClozeAnswerRevealsActiveGroup(t *testing.T) {
+	items := []deck.ReviewItem{
+		clozeItem("1", "The {{c1::capital::city}} of France is {{c2::Paris}}.", "c1"),
+	}
+	m := tui.NewReviewModel(items, nil)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	m = asReview(updated)
+	view := m.View()
+	if !strings.Contains(view, "capital") {
+		t.Errorf("answer should reveal active group c1, got:\n%s", view)
+	}
+	if !strings.Contains(view, "Paris") {
+		t.Errorf("answer should reveal inactive group c2, got:\n%s", view)
+	}
+	if strings.Contains(view, "city") {
+		t.Errorf("answer should not show placeholder hint, got:\n%s", view)
+	}
+}
+
+// TestClozeNoHintShowsEllipsis checks that a cloze marker without a hint
+// renders as [...] on the question side.
+func TestClozeNoHintShowsEllipsis(t *testing.T) {
+	items := []deck.ReviewItem{
+		clozeItem("1", "The answer is {{c1::42}}.", "c1"),
+	}
+	m := tui.NewReviewModel(items, nil)
+	view := m.View()
+	if strings.Contains(view, "42") {
+		t.Errorf("question should hide answer 42, got:\n%s", view)
+	}
+	if !strings.Contains(view, "...") {
+		t.Errorf("question should show placeholder containing '...', got:\n%s", view)
 	}
 }


### PR DESCRIPTION
## Summary

Implements Anki-compatible cloze deletion cards with per-group FSRS scheduling.

### Changes

- **`internal/card`**: Parse cloze cards with `clozes:` frontmatter map keyed by deletion group. Extract cloze groups from `{{cN::answer}}` and `{{cN::answer::hint}}` markers. Serialize cloze cards omitting flat FSRS fields, using per-group map instead.
- **`internal/deck`**: `BuildQueue` returns `ReviewItem` (card + optional `cloze_group`) pairs. Basic cards produce 1 item; cloze cards produce 1 per unique deletion group.
- **`internal/tui`**: Render cloze question hiding the active group as `[...]` (or `[hint]` if present), revealing all groups on answer. Other groups are always visible.
- **`internal/fsrs` / `internal/cli`**: `Rate` operates on `ReviewItem`, updating only the active group's FSRS state. Other groups are untouched.
- **`internal/store`**: `LogEntry.ClozeGroup` changed to `*string` (e.g. `"c1"`). JSONL entries include `cloze_group` for cloze ratings. Atomic rewrite preserves untouched cloze groups.

### Tests

- `TestExtractClozeGroups` — single, multi-group, hint, duplicate, no-groups fixtures
- `TestParseClozeCardWithGroups` / `TestRoundTripClozeCard` — round-trip FSRS state per group
- `TestQueueEnumeratesClozeGroups` — deck queue produces `(card, group)` pairs
- `TestMakeRateFuncUpdatesOnlyActiveClozeGroup` — rates one group, leaves others, logs group key
- `TestClozeQuestionHidesActiveGroup` / `TestClozeAnswerRevealsActiveGroup` — TUI render
- `TestClozeSerializeOmitsFlatFields` — frontmatter shape verification

Closes: #7