### PR TITLE
ci: add PR CI workflow

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: golangci/golangci-lint-action@v7
         with:
-          version: v2
+          version: v2.12.1
 
       - name: Run just ci
         run: just ci

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,0 +1,27 @@
+name: PR CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Install just
+        run: go install github.com/casey/just@latest
+
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+
+      - name: Run just ci
+        run: just ci
+
+      - name: Run goreleaser check
+        run: go install github.com/goreleaser/goreleaser/v2@latest && goreleaser check

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -14,14 +14,16 @@ jobs:
         with:
           go-version: "1.26"
 
-      - name: Install just
-        run: go install github.com/casey/just@latest
+      - uses: extractions/setup-just@v2
 
-      - name: Install golangci-lint
-        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+      - uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2
 
       - name: Run just ci
         run: just ci
 
       - name: Run goreleaser check
-        run: go install github.com/goreleaser/goreleaser/v2@latest && goreleaser check
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          args: check

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,12 @@
+version: 2
+
+builds:
+  - main: ./cmd/srs
+    binary: srs
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64

--- a/internal/card/card_test.go
+++ b/internal/card/card_test.go
@@ -290,9 +290,9 @@ func TestRoundTripClozeCard(t *testing.T) {
 // TestExtractClozeGroups finds all unique deletion groups in a body string.
 func TestExtractClozeGroups(t *testing.T) {
 	tests := []struct {
-		name  string
-		body  string
-		want  []string
+		name string
+		body string
+		want []string
 	}{
 		{
 			name: "single group",

--- a/internal/card/serialize_test.go
+++ b/internal/card/serialize_test.go
@@ -55,12 +55,12 @@ func TestClozeSerializeOmitsFlatFields(t *testing.T) {
 func TestBasicSerializeIncludesFlatFields(t *testing.T) {
 	c := &card.Card{
 		Meta: card.Meta{
-			Schema:  1,
-			ID:      "test-id",
-			Type:    card.Basic,
-			Created: "2026-01-01T00:00:00Z",
-			State:   "review",
-			Due:     "2026-02-01T00:00:00Z",
+			Schema:    1,
+			ID:        "test-id",
+			Type:      card.Basic,
+			Created:   "2026-01-01T00:00:00Z",
+			State:     "review",
+			Due:       "2026-02-01T00:00:00Z",
 			Stability: 5.0,
 		},
 		Front: "Q\n",

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -235,7 +235,9 @@ func TestMakeRateFuncUpdatesOnlyActiveClozeGroup(t *testing.T) {
 		Body:     "{{c1::A}} and {{c2::B}}\n",
 		FilePath: filepath.Join(cardDir, "cloze-1.md"),
 	}
-	os.WriteFile(c.FilePath, c.Serialize(), 0o644)
+	if err := os.WriteFile(c.FilePath, c.Serialize(), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
 
 	s := store.NewStore(stateDir, "testdeck")
 	rateFunc := cli.MakeRateFunc(s)
@@ -264,7 +266,7 @@ func TestMakeRateFuncUpdatesOnlyActiveClozeGroup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open jsonl: %v", err)
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {

--- a/internal/deck/deck_test.go
+++ b/internal/deck/deck_test.go
@@ -184,7 +184,9 @@ func TestQueueSkipsNonCardFiles(t *testing.T) {
 func TestQueueEnumeratesClozeGroups(t *testing.T) {
 	root := t.TempDir()
 	deckDir := filepath.Join(root, "mydeck")
-	os.MkdirAll(deckDir, 0o755)
+	if err := os.MkdirAll(deckDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
 
 	writeBasicCard(t, deckDir, "basic-1", "Q1", "A1")
 	writeClozeCard(t, deckDir, "cloze-1", "{{c1::A}} and {{c2::B}}", nil)


### PR DESCRIPTION
## Summary

- Add `.github/workflows/pr-ci.yml` — triggers on PRs to `main`, runs checkout → setup Go 1.26 → install just/golangci-lint → `just ci` → `goreleaser check`. No release logic.
- Add `.goreleaser.yml` — minimal v2 config so `goreleaser check` passes.
- Fix 3 pre-existing `errcheck` lint failures in test files (unchecked `os.WriteFile`, `f.Close`, `os.MkdirAll` return values) so `just ci` passes cleanly.

Closes: #20