### PR TITLE
feat(cli): add decks subcommand for plain-text deck listing

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -184,6 +185,7 @@ func NewRootCmd() *cobra.Command {
 	root.AddCommand(newReviewCmd())
 	root.AddCommand(newNewCmd())
 	root.AddCommand(newInitCmd())
+	root.AddCommand(newDecksCmd())
 	return root
 }
 
@@ -294,6 +296,40 @@ func newInitCmd() *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&force, "force", false, "overwrite existing config.toml")
 	return cmd
+}
+
+func newDecksCmd() *cobra.Command {
+	var decksRoot string
+	cmd := &cobra.Command{
+		Use:   "decks",
+		Short: "List deck names",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return RunDecks(paths.DecksRoot(decksRoot), cmd.OutOrStdout(), cmd.ErrOrStderr())
+		},
+		SilenceUsage: true,
+	}
+	cmd.Flags().StringVar(&decksRoot, "decks-root", "", "root directory for decks")
+	return cmd
+}
+
+// RunDecks discovers decks under decksRoot and prints their names sorted
+// alphabetically, one per line, to stdout. Diagnostics go to stderr.
+func RunDecks(decksRoot string, stdout, stderr io.Writer) error {
+	paths, err := deck.Discover(decksRoot)
+	if err != nil {
+		_, _ = fmt.Fprintf(stderr, "decks: %v\n", err)
+		return err
+	}
+	names := make([]string, len(paths))
+	for i, p := range paths {
+		names[i] = filepath.Base(p)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		_, _ = fmt.Fprintln(stdout, n)
+	}
+	return nil
 }
 
 // RunInit scaffolds the default config.toml in configDir and the decks directory

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -730,3 +730,168 @@ func TestInitSubcommandCreatesFiles(t *testing.T) {
 		t.Error("decks_root directory not created")
 	}
 }
+
+func TestDecksCommandPrintsOneNamePerLine(t *testing.T) {
+	tmpDir := t.TempDir()
+	for _, name := range []string{"french", "golang"} {
+		if err := os.MkdirAll(filepath.Join(tmpDir, name), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", name, err)
+		}
+	}
+
+	var stdout bytes.Buffer
+	cli.SetOutput(io.Discard)
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"decks", "--decks-root", tmpDir})
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("decks command failed: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("lines = %d, want 2; output=%q", len(lines), stdout.String())
+	}
+	if lines[0] != "french" {
+		t.Errorf("lines[0] = %q, want %q", lines[0], "french")
+	}
+	if lines[1] != "golang" {
+		t.Errorf("lines[1] = %q, want %q", lines[1], "golang")
+	}
+}
+
+func TestDecksCommandSortsAlphabetically(t *testing.T) {
+	tmpDir := t.TempDir()
+	for _, name := range []string{"zoo", "alpha", "med"} {
+		if err := os.MkdirAll(filepath.Join(tmpDir, name), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", name, err)
+		}
+	}
+
+	var stdout bytes.Buffer
+	cli.SetOutput(io.Discard)
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"decks", "--decks-root", tmpDir})
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("decks command failed: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n")
+	want := []string{"alpha", "med", "zoo"}
+	if len(lines) != len(want) {
+		t.Fatalf("lines = %v, want %v", lines, want)
+	}
+	for i, got := range lines {
+		if got != want[i] {
+			t.Errorf("lines[%d] = %q, want %q", i, got, want[i])
+		}
+	}
+}
+
+func TestDecksCommandUnreadableRootWritesStderrAndExits1(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	cli.SetOutput(io.Discard)
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"decks", "--decks-root", "/nonexistent/path/xyz"})
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for nonexistent decks_root")
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("stdout should be empty on error, got %q", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "decks:") {
+		t.Errorf("stderr should mention 'decks:', got %q", stderr.String())
+	}
+
+	code := cli.ExecuteWithArgs([]string{"decks", "--decks-root", "/nonexistent/path/xyz"})
+	if code != 1 {
+		t.Errorf("exit code = %d, want 1", code)
+	}
+}
+
+func TestDecksCommandNoHeaderNoTrailer(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, "french"), 0o755); err != nil {
+		t.Fatalf("mkdir french: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	cli.SetOutput(io.Discard)
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"decks", "--decks-root", tmpDir})
+	cmd.SetOut(&stdout)
+	cmd.SetErr(io.Discard)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("decks command failed: %v", err)
+	}
+
+	out := stdout.String()
+	if strings.HasPrefix(out, " ") || strings.HasPrefix(out, "\t") {
+		t.Errorf("output should not have leading whitespace: %q", out)
+	}
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if lines[0] != "french" {
+		t.Errorf("first line = %q, want %q (no header)", lines[0], "french")
+	}
+}
+
+func TestDecksCommandIgnoresFilesInRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, "french"), 0o755); err != nil {
+		t.Fatalf("mkdir french: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "notes.txt"), []byte("not a deck"), 0o644); err != nil {
+		t.Fatalf("write notes.txt: %v", err)
+	}
+
+	var stdout bytes.Buffer
+	cli.SetOutput(io.Discard)
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"decks", "--decks-root", tmpDir})
+	cmd.SetOut(&stdout)
+	cmd.SetErr(io.Discard)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("decks command failed: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n")
+	if len(lines) != 1 || lines[0] != "french" {
+		t.Errorf("output = %v, want only [french] (files ignored)", lines)
+	}
+}
+
+func TestDecksCommandEmptyRootPrintsNothing(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	var stdout bytes.Buffer
+	cli.SetOutput(io.Discard)
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"decks", "--decks-root", tmpDir})
+	cmd.SetOut(&stdout)
+	cmd.SetErr(io.Discard)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("decks command failed: %v", err)
+	}
+
+	if stdout.String() != "" {
+		t.Errorf("output should be empty for empty root, got %q", stdout.String())
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `srs decks` subcommand that prints one deck name per line on stdout, sorted alphabetically
- Diagnostics go to stderr with non-zero exit; stdout stays empty for clean pipeline failure
- Supports `--decks-root` flag (matching the `new` command pattern)
- Uses `cmd.ErrOrStderr()` for correct stderr routing with cobra

Closes: #9

## Acceptance criteria

- [x] `internal/cli` adds a `decks` subcommand
- [x] Output is plain text on stdout: one deck name per line, no header, no trailing decoration
- [x] Deck names are the immediate-child directory names of `decks_root` (matching deck-discovery semantics from #3)
- [x] Output is sorted alphabetically for stable scripting
- [x] Diagnostics (e.g. unreadable `decks_root`) go to stderr with a non-zero exit code; stdout remains empty
- [x] `srs decks | xargs -I{} srs review {}` is a sensible composition

## Tests

6 tests through the public CLI interface (`ExecuteWithArgs` / `NewRootCmd`):

1. `TestDecksCommandPrintsOneNamePerLine` — tracer bullet
2. `TestDecksCommandSortsAlphabetically` — proves sort with out-of-order names
3. `TestDecksCommandUnreadableRootWritesStderrAndExits1` — stderr + exit 1 + empty stdout
4. `TestDecksCommandNoHeaderNoTrailer` — no decoration in output
5. `TestDecksCommandIgnoresFilesInRoot` — regular files not listed
6. `TestDecksCommandEmptyRootPrintsNothing` — empty root → empty stdout, exit 0