### PR TITLE
ci: add release workflow with go-semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Install GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          install-only: true
+
+      - name: Semantic Release
+        id: semantic
+        uses: go-semantic-release/action@v1
+        with:
+          allow-initial-development-versions: true
+          hooks: goreleaser release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yml` triggered on push to `main`
- go-semantic-release with `allow-initial-development-versions` (stays on 0.x track)
- GoReleaser invoked as hook for cross-compiled binaries
- Full commit history via `fetch-depth: 0`
- Concurrency group `release` with `cancel-in-progress: false`

Closes: #22