### PR TITLE
feat(deck,store,config,cli): enforce new-card daily budget with midnight rollover

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -167,14 +167,25 @@ func MakeRateFunc(s *store.Store) tui.RateFunc {
 // defaultReviewRun builds the review queue for deckDir, opens the interactive
 // Bubble Tea review session, and persists ratings via MakeRateFunc.
 func defaultReviewRun(deckDir string) error {
-	items, err := deck.BuildQueue(deckDir)
+	cfg, _ := config.Load(paths.ConfigHome())
+	if cfg == nil {
+		cfg = config.Defaults()
+	}
+
+	now := time.Now()
+	deckSlug := filepath.Base(deckDir)
+	stateDir := filepath.Join(paths.StateHome(), "srs")
+	s := store.NewStore(stateDir, deckSlug)
+
+	items, err := deck.BuildQueue(deckDir, deck.QueueConfig{
+		NewPerDay: cfg.Review.NewPerDay,
+		Now:       now,
+		NewCount:  s.NewCountToday,
+	})
 	if err != nil {
 		return fmt.Errorf("review: %w", err)
 	}
 
-	deckSlug := filepath.Base(deckDir)
-	stateDir := filepath.Join(paths.StateHome(), "srs")
-	s := store.NewStore(stateDir, deckSlug)
 	rateFunc := MakeRateFunc(s)
 
 	m := tui.NewReviewModel(items, rateFunc)
@@ -192,6 +203,11 @@ func defaultPickerRun(decksRoot string) error {
 		return fmt.Errorf("picker: %w", err)
 	}
 
+	cfg, _ := config.Load(paths.ConfigHome())
+	if cfg == nil {
+		cfg = config.Defaults()
+	}
+
 	now := time.Now()
 	var entries []tui.DeckEntry
 	for _, dp := range deckPaths {
@@ -205,12 +221,16 @@ func defaultPickerRun(decksRoot string) error {
 
 	stateDir := filepath.Join(paths.StateHome(), "srs")
 	onSelect := func(e tui.DeckEntry) (tea.Model, tea.Cmd) {
-		items, qErr := deck.BuildQueue(e.Path)
+		deckSlug := filepath.Base(e.Path)
+		s := store.NewStore(stateDir, deckSlug)
+		items, qErr := deck.BuildQueue(e.Path, deck.QueueConfig{
+			NewPerDay: cfg.Review.NewPerDay,
+			Now:       now,
+			NewCount:  s.NewCountToday,
+		})
 		if qErr != nil {
 			return nil, tea.Quit
 		}
-		deckSlug := filepath.Base(e.Path)
-		s := store.NewStore(stateDir, deckSlug)
 		rateFunc := MakeRateFunc(s)
 		return tui.NewReviewModel(items, rateFunc), nil
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -78,6 +79,10 @@ func Load(configDir string) (*Config, error) {
 	}
 
 	cfg.Paths.DecksRoot = paths.ExpandHome(cfg.Paths.DecksRoot)
+
+	if cfg.Review.NewPerDay < 0 {
+		return nil, fmt.Errorf("config: review.new_per_day must be non-negative, got %d", cfg.Review.NewPerDay)
+	}
 
 	return cfg, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -136,3 +136,25 @@ decks_root = "~/my-decks"
 		t.Errorf("Paths.DecksRoot = %q, want %q", cfg.Paths.DecksRoot, want)
 	}
 }
+
+// TestLoadRejectsNegativeNewPerDay verifies that Load returns an error when
+// new_per_day is set to a negative value in the config file.
+func TestLoadRejectsNegativeNewPerDay(t *testing.T) {
+	dir := t.TempDir()
+	srsDir := filepath.Join(dir, "srs")
+	if err := os.MkdirAll(srsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tomlContent := `[review]
+new_per_day = -5
+`
+	if err := os.WriteFile(filepath.Join(srsDir, "config.toml"), []byte(tomlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := config.Load(dir)
+	if err == nil {
+		t.Fatal("Load() should return error for negative new_per_day")
+	}
+}

--- a/internal/deck/deck.go
+++ b/internal/deck/deck.go
@@ -6,6 +6,7 @@ import (
 	"math/rand/v2"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/jvcorredor/srs-tui/internal/card"
@@ -17,6 +18,17 @@ import (
 type ReviewItem struct {
 	Card       *card.Card
 	ClozeGroup string
+}
+
+// QueueConfig controls how BuildQueue assembles the review queue.
+type QueueConfig struct {
+	// NewPerDay is the daily ceiling on how many state:new cards enter the queue.
+	NewPerDay int
+	// Now is the reference time for due-date comparisons and midnight rollover.
+	Now time.Time
+	// NewCount returns how many new cards have already been reviewed today
+	// (i.e. log entries where prev.state == "new" for the current local-calendar day).
+	NewCount func(now time.Time) (int, error)
 }
 
 // Discover returns the absolute paths of every immediate subdirectory inside
@@ -45,8 +57,14 @@ func Discover(root string) ([]string, error) {
 // and returns review items in random order. Basic cards produce a single item;
 // cloze cards produce one item per unique cloze group found in the body.
 // Files that cannot be parsed as cards or that lack frontmatter are skipped.
-func BuildQueue(deckDir string) ([]ReviewItem, error) {
-	var items []ReviewItem
+//
+// The cfg parameter controls new-card budgeting: at most cfg.NewPerDay new
+// cards are admitted per local-calendar day, minus any already reviewed today
+// (counted by cfg.NewCount). Due review cards are unbounded. New cards are
+// ordered by created ASC before capping, then merged with due reviews and
+// shuffled.
+func BuildQueue(deckDir string, cfg QueueConfig) ([]ReviewItem, error) {
+	var newItems, reviewItems []ReviewItem
 	err := filepath.WalkDir(deckDir, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -64,28 +82,65 @@ func BuildQueue(deckDir string) ([]ReviewItem, error) {
 		if c == nil {
 			return nil
 		}
-		if c.Type == card.Cloze {
-			groups := card.ExtractClozeGroups(c.Body)
-			if len(groups) == 0 {
-				// No cloze markers found; enqueue as a single item.
-				items = append(items, ReviewItem{Card: c})
-			} else {
-				for _, g := range groups {
-					items = append(items, ReviewItem{Card: c, ClozeGroup: g})
-				}
-			}
-		} else {
-			items = append(items, ReviewItem{Card: c})
-		}
+		classifyItems(c, &newItems, &reviewItems, cfg.Now)
 		return nil
 	})
 	if err != nil {
 		return nil, err
 	}
+
+	remaining := cfg.NewPerDay
+	if cfg.NewCount != nil {
+		done, err := cfg.NewCount(cfg.Now)
+		if err != nil {
+			return nil, err
+		}
+		remaining -= done
+	}
+	if remaining < 0 {
+		remaining = 0
+	}
+
+	sortByCreated(newItems)
+	if len(newItems) > remaining {
+		newItems = newItems[:remaining]
+	}
+
+	items := append(reviewItems, newItems...)
 	rand.Shuffle(len(items), func(i, j int) {
 		items[i], items[j] = items[j], items[i]
 	})
 	return items, nil
+}
+
+// classifyItems partitions a card's review items into newItems and reviewItems
+// based on their FSRS state and due status at the given time.
+func classifyItems(c *card.Card, newItems, reviewItems *[]ReviewItem, now time.Time) {
+	if c.Type == card.Cloze {
+		groups := card.ExtractClozeGroups(c.Body)
+		if len(groups) == 0 {
+			classifyOne(c, "", newItems, reviewItems, now)
+		} else {
+			for _, g := range groups {
+				classifyOne(c, g, newItems, reviewItems, now)
+			}
+		}
+	} else {
+		classifyOne(c, "", newItems, reviewItems, now)
+	}
+}
+
+// classifyOne classifies a single review item as new, due, or neither.
+func classifyOne(c *card.Card, group string, newItems, reviewItems *[]ReviewItem, now time.Time) {
+	item := ReviewItem{Card: c}
+	if group != "" {
+		item.ClozeGroup = group
+	}
+	if isItemNew(c.Meta, group) {
+		*newItems = append(*newItems, item)
+	} else if isItemDue(c.Meta, group, now) {
+		*reviewItems = append(*reviewItems, item)
+	}
 }
 
 // DueCount returns the number of review items in the deck that are due for
@@ -157,4 +212,21 @@ func isItemDue(meta card.Meta, group string, now time.Time) bool {
 	}
 	due := fsrs.ParseTime(meta.Due)
 	return !due.IsZero() && !due.After(now)
+}
+
+// isItemNew reports whether a review item is in the "new" state.
+func isItemNew(meta card.Meta, group string) bool {
+	if group != "" {
+		if cg, ok := meta.Clozes[group]; ok {
+			return fsrs.NormalizeState(cg.State) == fsrs.StateNew
+		}
+	}
+	return fsrs.NormalizeState(meta.State) == fsrs.StateNew
+}
+
+// sortByCreated sorts review items by their card's Created timestamp ASC.
+func sortByCreated(items []ReviewItem) {
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Card.Created < items[j].Card.Created
+	})
 }

--- a/internal/deck/deck_test.go
+++ b/internal/deck/deck_test.go
@@ -149,7 +149,8 @@ func TestDiscoverFollowsSymlinks(t *testing.T) {
 }
 
 // TestQueueContainsAllCardsShuffled confirms that BuildQueue finds every
-// card in the deck and returns them in a shuffled order.
+// card in the deck and returns them in a shuffled order when the new-card
+// budget is effectively unlimited.
 func TestQueueContainsAllCardsShuffled(t *testing.T) {
 	root := t.TempDir()
 	deckDir := filepath.Join(root, "mydeck")
@@ -161,7 +162,11 @@ func TestQueueContainsAllCardsShuffled(t *testing.T) {
 	writeBasicCard(t, deckDir, "id-2", "Q2", "A2")
 	writeBasicCard(t, deckDir, "id-3", "Q3", "A3")
 
-	q, err := deck.BuildQueue(deckDir)
+	q, err := deck.BuildQueue(deckDir, deck.QueueConfig{
+		NewPerDay: 20,
+		Now:       time.Now(),
+		NewCount:  func(_ time.Time) (int, error) { return 0, nil },
+	})
 	if err != nil {
 		t.Fatalf("BuildQueue() error: %v", err)
 	}
@@ -194,7 +199,11 @@ func TestQueueSkipsNonCardFiles(t *testing.T) {
 		t.Fatalf("write readme: %v", err)
 	}
 
-	q, err := deck.BuildQueue(deckDir)
+	q, err := deck.BuildQueue(deckDir, deck.QueueConfig{
+		NewPerDay: 20,
+		Now:       time.Now(),
+		NewCount:  func(_ time.Time) (int, error) { return 0, nil },
+	})
 	if err != nil {
 		t.Fatalf("BuildQueue() error: %v", err)
 	}
@@ -218,7 +227,11 @@ func TestQueueEnumeratesClozeGroups(t *testing.T) {
 	writeBasicCard(t, deckDir, "basic-1", "Q1", "A1")
 	writeClozeCard(t, deckDir, "cloze-1", "{{c1::A}} and {{c2::B}}", nil)
 
-	q, err := deck.BuildQueue(deckDir)
+	q, err := deck.BuildQueue(deckDir, deck.QueueConfig{
+		NewPerDay: 20,
+		Now:       time.Now(),
+		NewCount:  func(_ time.Time) (int, error) { return 0, nil },
+	})
 	if err != nil {
 		t.Fatalf("BuildQueue() error: %v", err)
 	}
@@ -283,5 +296,176 @@ func TestDueCountCountsNewAndDueCards(t *testing.T) {
 	}
 	if count != 2 {
 		t.Errorf("DueCount = %d, want 2 (new + due, excluding future)", count)
+	}
+}
+
+// TestQueueHonorsNewPerDayBudget verifies that BuildQueue limits new cards
+// to the remaining daily budget. If 15 new cards were already reviewed today
+// and new_per_day is 20, only 5 new cards enter the queue. Due review cards
+// are unaffected by the budget.
+func TestQueueHonorsNewPerDayBudget(t *testing.T) {
+	root := t.TempDir()
+	deckDir := filepath.Join(root, "mydeck")
+	if err := os.MkdirAll(deckDir, 0o755); err != nil {
+		t.Fatalf("mkdir deck: %v", err)
+	}
+
+	now := time.Now()
+
+	writeBasicCardWithState(t, deckDir, "new-1", "Q1", "A1", fsrs.CardState{
+		State: fsrs.StateNew,
+	})
+	writeBasicCardWithState(t, deckDir, "new-2", "Q2", "A2", fsrs.CardState{
+		State: fsrs.StateNew,
+	})
+	writeBasicCardWithState(t, deckDir, "new-3", "Q3", "A3", fsrs.CardState{
+		State: fsrs.StateNew,
+	})
+	writeBasicCardWithState(t, deckDir, "due-review", "Q4", "A4", fsrs.CardState{
+		State:     fsrs.StateReview,
+		Due:       now.Add(-1 * time.Hour),
+		Stability: 10,
+	})
+
+	q, err := deck.BuildQueue(deckDir, deck.QueueConfig{
+		NewPerDay: 20,
+		Now:       now,
+		NewCount:  func(_ time.Time) (int, error) { return 18, nil },
+	})
+	if err != nil {
+		t.Fatalf("BuildQueue() error: %v", err)
+	}
+
+	newCount := 0
+	reviewCount := 0
+	for _, it := range q {
+		state := fsrs.NormalizeState(it.Card.State)
+		if state == fsrs.StateNew {
+			newCount++
+		} else {
+			reviewCount++
+		}
+	}
+
+	if newCount != 2 {
+		t.Errorf("new cards in queue = %d, want 2 (budget 20 - 18 done = 2 remaining)", newCount)
+	}
+	if reviewCount != 1 {
+		t.Errorf("review cards in queue = %d, want 1 (reviews are unbounded)", reviewCount)
+	}
+}
+
+// TestQueueBudgetResetsAcrossMidnight verifies that the new-card budget
+// resets at midnight. When NewCount reports 0 for the new day (no new
+// cards reviewed yet), all new cards are admitted up to the full budget.
+func TestQueueBudgetResetsAcrossMidnight(t *testing.T) {
+	root := t.TempDir()
+	deckDir := filepath.Join(root, "mydeck")
+	if err := os.MkdirAll(deckDir, 0o755); err != nil {
+		t.Fatalf("mkdir deck: %v", err)
+	}
+
+	writeBasicCardWithState(t, deckDir, "new-1", "Q1", "A1", fsrs.CardState{
+		State: fsrs.StateNew,
+	})
+	writeBasicCardWithState(t, deckDir, "new-2", "Q2", "A2", fsrs.CardState{
+		State: fsrs.StateNew,
+	})
+
+	now := time.Now()
+
+	q, err := deck.BuildQueue(deckDir, deck.QueueConfig{
+		NewPerDay: 20,
+		Now:       now,
+		NewCount:  func(_ time.Time) (int, error) { return 0, nil },
+	})
+	if err != nil {
+		t.Fatalf("BuildQueue() error: %v", err)
+	}
+
+	newCount := 0
+	for _, it := range q {
+		if fsrs.NormalizeState(it.Card.State) == fsrs.StateNew {
+			newCount++
+		}
+	}
+	if newCount != 2 {
+		t.Errorf("new cards in queue after midnight = %d, want 2 (budget reset)", newCount)
+	}
+}
+
+// TestQueueZeroBudgetAdmitsNoNewCards verifies that setting new_per_day to
+// zero prevents any new cards from entering the queue, while due review
+// cards are still admitted.
+func TestQueueZeroBudgetAdmitsNoNewCards(t *testing.T) {
+	root := t.TempDir()
+	deckDir := filepath.Join(root, "mydeck")
+	if err := os.MkdirAll(deckDir, 0o755); err != nil {
+		t.Fatalf("mkdir deck: %v", err)
+	}
+
+	now := time.Now()
+
+	writeBasicCardWithState(t, deckDir, "new-1", "Q1", "A1", fsrs.CardState{
+		State: fsrs.StateNew,
+	})
+	writeBasicCardWithState(t, deckDir, "due-review", "Q2", "A2", fsrs.CardState{
+		State:     fsrs.StateReview,
+		Due:       now.Add(-1 * time.Hour),
+		Stability: 10,
+	})
+
+	q, err := deck.BuildQueue(deckDir, deck.QueueConfig{
+		NewPerDay: 0,
+		Now:       now,
+		NewCount:  func(_ time.Time) (int, error) { return 0, nil },
+	})
+	if err != nil {
+		t.Fatalf("BuildQueue() error: %v", err)
+	}
+
+	for _, it := range q {
+		if fsrs.NormalizeState(it.Card.State) == fsrs.StateNew {
+			t.Errorf("new card %q admitted with zero budget", it.Card.ID)
+		}
+	}
+	if len(q) != 1 {
+		t.Errorf("queue length = %d, want 1 (only due review card)", len(q))
+	}
+}
+
+// TestQueueBudgetLargerThanAvailableNewCards verifies that when the budget
+// exceeds the number of available new cards, all new cards are admitted.
+func TestQueueBudgetLargerThanAvailableNewCards(t *testing.T) {
+	root := t.TempDir()
+	deckDir := filepath.Join(root, "mydeck")
+	if err := os.MkdirAll(deckDir, 0o755); err != nil {
+		t.Fatalf("mkdir deck: %v", err)
+	}
+
+	writeBasicCardWithState(t, deckDir, "new-1", "Q1", "A1", fsrs.CardState{
+		State: fsrs.StateNew,
+	})
+	writeBasicCardWithState(t, deckDir, "new-2", "Q2", "A2", fsrs.CardState{
+		State: fsrs.StateNew,
+	})
+
+	q, err := deck.BuildQueue(deckDir, deck.QueueConfig{
+		NewPerDay: 100,
+		Now:       time.Now(),
+		NewCount:  func(_ time.Time) (int, error) { return 0, nil },
+	})
+	if err != nil {
+		t.Fatalf("BuildQueue() error: %v", err)
+	}
+
+	newCount := 0
+	for _, it := range q {
+		if fsrs.NormalizeState(it.Card.State) == fsrs.StateNew {
+			newCount++
+		}
+	}
+	if newCount != 2 {
+		t.Errorf("new cards in queue = %d, want 2 (all available new cards admitted)", newCount)
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4,6 +4,7 @@
 package store
 
 import (
+	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -142,3 +143,34 @@ func (s *Store) DeckSlug() string { return s.deckSlug }
 
 // LogPath returns the full path to the JSONL review log file.
 func (s *Store) LogPath() string { return s.logPath }
+
+// NewCountToday counts log entries where the card was previously in the "new"
+// state and the entry timestamp falls on the same local-calendar day as now.
+// It reads the JSONL log file associated with this store's deck.
+func (s *Store) NewCountToday(now time.Time) (int, error) {
+	f, err := os.Open(s.logPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	defer func() { _ = f.Close() }()
+
+	today := now.Local().Truncate(24 * time.Hour)
+	var count int
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var entry LogEntry
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			continue
+		}
+		if entry.Prev.State != fsrs.StateNew {
+			continue
+		}
+		if entry.TS.Local().Truncate(24 * time.Hour).Equal(today) {
+			count++
+		}
+	}
+	return count, scanner.Err()
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -302,3 +302,59 @@ func TestEnsureIDNoOpWhenCardHasID(t *testing.T) {
 		t.Errorf("ID changed from %q to %q", "existing-id", c.ID)
 	}
 }
+
+// TestNewCountTodayCountsOnlyToday checks that NewCountToday only counts
+// log entries where prev.state == "new" and the timestamp falls on the same
+// local-calendar day as the supplied "now" parameter. Entries from previous
+// days and non-new entries are excluded.
+func TestNewCountTodayCountsOnlyToday(t *testing.T) {
+	dir := t.TempDir()
+	s := store.NewStore(dir, "mydeck")
+
+	today := time.Now().Local().Truncate(24 * time.Hour).Add(12 * time.Hour)
+	yesterday := today.Add(-24 * time.Hour)
+
+	newEntry := func(ts time.Time, prevState fsrs.State) store.LogEntry {
+		return store.LogEntry{
+			Schema: 1,
+			TS:     ts.UTC().Truncate(time.Millisecond),
+			CardID: "card-1",
+			Rating: 3,
+			Prev:   fsrs.CardState{State: prevState},
+			Next:   fsrs.CardState{State: fsrs.StateLearning},
+		}
+	}
+
+	if err := s.AppendLog(newEntry(yesterday, fsrs.StateNew)); err != nil {
+		t.Fatalf("append yesterday: %v", err)
+	}
+	if err := s.AppendLog(newEntry(today, fsrs.StateNew)); err != nil {
+		t.Fatalf("append today new: %v", err)
+	}
+	if err := s.AppendLog(newEntry(today, fsrs.StateReview)); err != nil {
+		t.Fatalf("append today review: %v", err)
+	}
+
+	count, err := s.NewCountToday(today)
+	if err != nil {
+		t.Fatalf("NewCountToday() error: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("NewCountToday = %d, want 1 (only today's new entries)", count)
+	}
+}
+
+// TestNewCountTodayReturnsZeroWhenNoLog ensures NewCountToday returns 0
+// without error when the log file does not exist.
+func TestNewCountTodayReturnsZeroWhenNoLog(t *testing.T) {
+	dir := t.TempDir()
+	s := store.NewStore(dir, "mydeck")
+
+	count, err := s.NewCountToday(time.Now())
+	if err != nil {
+		t.Fatalf("NewCountToday() error: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("NewCountToday = %d, want 0", count)
+	}
+}


### PR DESCRIPTION
## Summary

- `BuildQueue` now accepts `QueueConfig` with `NewPerDay`, `Now`, and injectable `NewCount` — new cards are capped at `new_per_day - already_done_today`, ordered by `created` ASC, then merged with unbounded due reviews and shuffled
- `store.NewCountToday` reads the deck's JSONL log and counts entries where `prev.state == "new"` on the same local-calendar day as `now` (midnight rollover via `time.Local().Truncate(24h)`)
- `config.Load` validates `review.new_per_day` as a non-negative integer

## Acceptance criteria (#10)

- [x] `review.new_per_day` loaded from config (default 20) and validated as non-negative
- [x] Queue construction enforces budget: counts log entries from today where `prev.state == "new"` and admits up to `new_per_day - already_done_today` new cards
- [x] New cards ordered by `created` ASC, capped at remaining budget, merged with due reviews, shuffled
- [x] Reviews are unbounded — no daily review cap
- [x] `today` derived from `time.Now().Local()`; midnight rollover only
- [x] Tests use injected `NewCount` func for deterministic "today" across midnight boundaries
- [x] Tests cover: budget honored, budget reset across midnight, zero budget, budget larger than available

Closes: #10