### PR TITLE
fix(ci): use goreleaser hooks plugin name and add write permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+  contents: write
+
 on:
   push:
     branches: [main]
@@ -30,6 +33,6 @@ jobs:
         uses: go-semantic-release/action@v1
         with:
           allow-initial-development-versions: true
-          hooks: goreleaser release --clean
+          hooks: goreleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- `hooks` input takes a plugin name (`goreleaser`), not a shell command
- Added `permissions: contents: write` for release creation

Closes: #22