### PR TITLE
feat(tui): add quality-of-life review keybindings (e, u, s, ?, q-confirm)

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -96,7 +96,7 @@ func defaultEditorRun(file string) error {
 // card's Markdown file, and returns the next state together with interval
 // previews. For cloze cards, only the active group's state is updated.
 func MakeRateFunc(s *store.Store) tui.RateFunc {
-	return func(it *deck.ReviewItem, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, error) {
+	return func(it *deck.ReviewItem, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, store.LogEntry, error) {
 		var prevState fsrs.CardState
 		if it.Card.Type == card.Cloze && it.ClozeGroup != "" {
 			if g, ok := it.Card.Clozes[it.ClozeGroup]; ok {
@@ -122,7 +122,7 @@ func MakeRateFunc(s *store.Store) tui.RateFunc {
 
 		nextState, previews, err := fsrs.Rate(prevState, rating, now)
 		if err != nil {
-			return fsrs.CardState{}, nil, err
+			return fsrs.CardState{}, nil, store.LogEntry{}, err
 		}
 
 		store.EnsureID(it.Card)
@@ -158,10 +158,24 @@ func MakeRateFunc(s *store.Store) tui.RateFunc {
 		}
 
 		if err := s.Persist(entry, it.Card.FilePath, it.Card); err != nil {
-			return nextState, previews, fmt.Errorf("persist: %w", err)
+			return nextState, previews, entry, fmt.Errorf("persist: %w", err)
 		}
 
-		return nextState, previews, nil
+		return nextState, previews, entry, nil
+	}
+}
+
+// MakeUndoFunc builds a tui.UndoFunc that reverses the last rating by truncating
+// the JSONL log and rewriting the card file to its prior FSRS state.
+func MakeUndoFunc(s *store.Store) tui.UndoFunc {
+	return func(entry store.LogEntry, cardPath string, c *card.Card) error {
+		if err := s.TruncateLastLog(entry); err != nil {
+			return fmt.Errorf("undo: truncate log: %w", err)
+		}
+		if err := s.RewriteCard(cardPath, c); err != nil {
+			return fmt.Errorf("undo: rewrite card: %w", err)
+		}
+		return nil
 	}
 }
 
@@ -188,8 +202,12 @@ func defaultReviewRun(deckDir string) error {
 	}
 
 	rateFunc := MakeRateFunc(s)
+	undoFunc := MakeUndoFunc(s)
 
-	m := tui.NewReviewModel(items, rateFunc)
+	m := tui.NewReviewModel(items, rateFunc,
+		tui.WithEditorCmd(tui.EditorExecCmd),
+		tui.WithUndoFunc(undoFunc),
+	)
 	p := tea.NewProgram(m, tea.WithAltScreen())
 	_, err = p.Run()
 	return err
@@ -233,7 +251,11 @@ func defaultPickerRun(decksRoot string) error {
 			return nil, tea.Quit
 		}
 		rateFunc := MakeRateFunc(s)
-		return tui.NewReviewModel(items, rateFunc), nil
+		undoFunc := MakeUndoFunc(s)
+		return tui.NewReviewModel(items, rateFunc,
+			tui.WithEditorCmd(tui.EditorExecCmd),
+			tui.WithUndoFunc(undoFunc),
+		), nil
 	}
 
 	m := tui.NewPickerModel(entries, onSelect)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -170,7 +170,7 @@ func TestMakeRateFuncPersistsRating(t *testing.T) {
 	rateFunc := cli.MakeRateFunc(s)
 
 	now := time.Now()
-	nextState, previews, err := rateFunc(&deck.ReviewItem{Card: c}, 3, now)
+	nextState, previews, _, err := rateFunc(&deck.ReviewItem{Card: c}, 3, now)
 	if err != nil {
 		t.Fatalf("rateFunc() error: %v", err)
 	}
@@ -252,7 +252,7 @@ func TestMakeRateFuncUpdatesOnlyActiveClozeGroup(t *testing.T) {
 
 	now := time.Now()
 	item := &deck.ReviewItem{Card: c, ClozeGroup: "c1"}
-	nextState, _, err := rateFunc(item, 3, now)
+	nextState, _, _, err := rateFunc(item, 3, now)
 	if err != nil {
 		t.Fatalf("rateFunc() error: %v", err)
 	}
@@ -533,7 +533,7 @@ func TestMakeRateFuncAssignsID(t *testing.T) {
 	s := store.NewStore(stateDir, "testdeck")
 	rateFunc := cli.MakeRateFunc(s)
 
-	_, _, err := rateFunc(&deck.ReviewItem{Card: c}, 3, time.Now())
+	_, _, _, err := rateFunc(&deck.ReviewItem{Card: c}, 3, time.Now())
 	if err != nil {
 		t.Fatalf("rateFunc() error: %v", err)
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -144,6 +144,35 @@ func (s *Store) DeckSlug() string { return s.deckSlug }
 // LogPath returns the full path to the JSONL review log file.
 func (s *Store) LogPath() string { return s.logPath }
 
+// TruncateLastLog removes the last log entry matching entry from the JSONL
+// log file by truncating the file at the position where the matching line begins.
+func (s *Store) TruncateLastLog(entry LogEntry) error {
+	f, err := os.Open(s.logPath)
+	if err != nil {
+		return fmt.Errorf("store: truncate: open: %w", err)
+	}
+
+	var offset int64
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var e LogEntry
+		if err := json.Unmarshal(scanner.Bytes(), &e); err != nil {
+			continue
+		}
+		if e.TS.Equal(entry.TS) && e.CardID == entry.CardID && e.Rating == entry.Rating {
+			break
+		}
+		offset += int64(len(scanner.Bytes())) + 1
+	}
+	scanErr := scanner.Err()
+	_ = f.Close()
+	if scanErr != nil {
+		return fmt.Errorf("store: truncate: scan: %w", scanErr)
+	}
+
+	return os.Truncate(s.logPath, offset)
+}
+
 // NewCountToday counts log entries where the card was previously in the "new"
 // state and the entry timestamp falls on the same local-calendar day as now.
 // It reads the JSONL log file associated with this store's deck.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -358,3 +358,61 @@ func TestNewCountTodayReturnsZeroWhenNoLog(t *testing.T) {
 		t.Errorf("NewCountToday = %d, want 0", count)
 	}
 }
+
+// TestTruncateLastLogRemovesMatchingEntry verifies that TruncateLastLog
+// removes the last log entry matching the given entry and leaves earlier
+// entries intact.
+func TestTruncateLastLogRemovesMatchingEntry(t *testing.T) {
+	dir := t.TempDir()
+	s := store.NewStore(dir, "mydeck")
+
+	entry1 := store.LogEntry{
+		Schema: 1,
+		TS:     time.Date(2026, 1, 1, 10, 0, 0, 0, time.UTC),
+		CardID: "card-1",
+		Rating: 3,
+		Prev:   fsrs.CardState{State: fsrs.StateNew},
+		Next:   fsrs.CardState{State: fsrs.StateLearning},
+	}
+	entry2 := store.LogEntry{
+		Schema: 1,
+		TS:     time.Date(2026, 1, 1, 10, 1, 0, 0, time.UTC),
+		CardID: "card-2",
+		Rating: 4,
+		Prev:   fsrs.CardState{State: fsrs.StateNew},
+		Next:   fsrs.CardState{State: fsrs.StateReview},
+	}
+
+	if err := s.AppendLog(entry1); err != nil {
+		t.Fatalf("AppendLog entry1: %v", err)
+	}
+	if err := s.AppendLog(entry2); err != nil {
+		t.Fatalf("AppendLog entry2: %v", err)
+	}
+
+	if err := s.TruncateLastLog(entry2); err != nil {
+		t.Fatalf("TruncateLastLog: %v", err)
+	}
+
+	f, err := os.Open(filepath.Join(dir, "mydeck.jsonl"))
+	if err != nil {
+		t.Fatalf("open log: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var remaining []store.LogEntry
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var e store.LogEntry
+		if err := json.Unmarshal(scanner.Bytes(), &e); err != nil {
+			continue
+		}
+		remaining = append(remaining, e)
+	}
+	if len(remaining) != 1 {
+		t.Fatalf("after truncating last entry, got %d entries, want 1", len(remaining))
+	}
+	if remaining[0].CardID != "card-1" {
+		t.Errorf("remaining entry should be card-1, got %s", remaining[0].CardID)
+	}
+}

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/card"
 	"github.com/jvcorredor/srs-tui/internal/deck"
 	"github.com/jvcorredor/srs-tui/internal/fsrs"
+	"github.com/jvcorredor/srs-tui/internal/store"
 	"github.com/jvcorredor/srs-tui/internal/tui"
 )
 
@@ -20,7 +21,7 @@ func pickerBasicItem(id, front, back string) deck.ReviewItem {
 }
 
 // pickerFakeRateFunc is a stub RateFunc for picker tests.
-func pickerFakeRateFunc(item *deck.ReviewItem, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, error) {
+func pickerFakeRateFunc(item *deck.ReviewItem, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, store.LogEntry, error) {
 	next := fsrs.CardState{State: fsrs.StateLearning, Stability: 1.5}
 	previews := []fsrs.IntervalPreview{
 		{Rating: 1, State: fsrs.StateLearning, Interval: 1 * time.Minute},
@@ -28,7 +29,8 @@ func pickerFakeRateFunc(item *deck.ReviewItem, rating int, now time.Time) (fsrs.
 		{Rating: 3, State: fsrs.StateLearning, Interval: 10 * time.Minute},
 		{Rating: 4, State: fsrs.StateReview, Interval: 24 * time.Hour},
 	}
-	return next, previews, nil
+	entry := store.LogEntry{Schema: 1, TS: now, CardID: item.Card.ID, Rating: rating, Prev: fsrs.CardState{State: fsrs.StateNew}, Next: next}
+	return next, previews, entry, nil
 }
 
 // asPicker asserts that a tea.Model is a tui.PickerModel and returns it.

--- a/internal/tui/review.go
+++ b/internal/tui/review.go
@@ -12,6 +12,8 @@ package tui
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
 	"regexp"
 	"strings"
 	"time"
@@ -22,11 +24,12 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/card"
 	"github.com/jvcorredor/srs-tui/internal/deck"
 	"github.com/jvcorredor/srs-tui/internal/fsrs"
+	"github.com/jvcorredor/srs-tui/internal/store"
 )
 
 // RateFunc applies a user rating to a review item and returns the resulting
 // state, interval previews for all possible ratings, and any error.
-type RateFunc func(item *deck.ReviewItem, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, error)
+type RateFunc func(item *deck.ReviewItem, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, store.LogEntry, error)
 
 // ReviewModel is a Bubble Tea model that drives a flash-card review session.
 // It manages a deck of review items, tracks which side is visible, and
@@ -35,25 +38,97 @@ type ReviewModel struct {
 	items        []deck.ReviewItem
 	index        int
 	showingBack  bool
+	showingHelp  bool
+	quitConfirm  bool
 	renderer     *glamour.TermRenderer
 	rateFunc     RateFunc
 	previews     []fsrs.IntervalPreview
 	done         bool
 	ratingCounts map[int]int
 	skippedCount int
+	editorCmd    EditorCmdFunc
+	cardReadFunc func(string) (*card.Card, error)
+	editErr      string
+	undoFunc     UndoFunc
+	undoable     *undoInfo
+}
+
+type undoInfo struct {
+	entry    store.LogEntry
+	cardPath string
+	card     *card.Card
+	rating   int
+}
+
+// EditorCmdFunc returns a tea.Cmd that opens the card at path in an editor.
+type EditorCmdFunc func(path string) tea.Cmd
+
+// UndoFunc reverses a persisted rating by truncating the log and rewriting
+// the card to its prior FSRS state.
+type UndoFunc func(entry store.LogEntry, cardPath string, c *card.Card) error
+
+type modelOption func(*ReviewModel)
+
+// WithEditorCmd sets the editor command function used when pressing 'e'.
+func WithEditorCmd(fn EditorCmdFunc) modelOption {
+	return func(m *ReviewModel) { m.editorCmd = fn }
+}
+
+// WithCardReadFunc sets the function used to re-read a card from disk after
+// the editor exits.
+func WithCardReadFunc(fn func(string) (*card.Card, error)) modelOption {
+	return func(m *ReviewModel) { m.cardReadFunc = fn }
+}
+
+// WithUndoFunc sets the function used to reverse the last persisted rating.
+func WithUndoFunc(fn UndoFunc) modelOption {
+	return func(m *ReviewModel) { m.undoFunc = fn }
+}
+
+// EditFinishedMsg is sent when the external editor finishes editing a card.
+type EditFinishedMsg struct {
+	Path string
+	Err  error
 }
 
 // NewReviewModel creates a ReviewModel for the given review items. The
 // rateFunc is invoked each time the user presses a rating key (1–4) while
 // the back side is visible.
-func NewReviewModel(items []deck.ReviewItem, rateFunc RateFunc) ReviewModel {
+func NewReviewModel(items []deck.ReviewItem, rateFunc RateFunc, opts ...modelOption) ReviewModel {
 	r, _ := glamour.NewTermRenderer(glamour.WithStandardStyle("dark"))
-	return ReviewModel{
+	m := ReviewModel{
 		items:        items,
 		renderer:     r,
 		rateFunc:     rateFunc,
 		ratingCounts: make(map[int]int),
 	}
+	for _, opt := range opts {
+		opt(&m)
+	}
+	if m.editorCmd == nil {
+		m.editorCmd = EditorExecCmd
+	}
+	if m.cardReadFunc == nil {
+		m.cardReadFunc = card.ParseFile
+	}
+	return m
+}
+
+func findEditor() string {
+	if e := os.Getenv("EDITOR"); e != "" {
+		return e
+	}
+	return "vi"
+}
+
+// EditorExecCmd returns a tea.Cmd that opens the card at path in the system
+// editor, suspending the TUI while the editor runs.
+func EditorExecCmd(path string) tea.Cmd {
+	editor := findEditor()
+	c := exec.Command(editor, path)
+	return tea.ExecProcess(c, func(err error) tea.Msg {
+		return EditFinishedMsg{Path: path, Err: err}
+	})
 }
 
 // ShowingBack reports whether the answer side of the current card is visible.
@@ -103,8 +178,31 @@ func (m ReviewModel) Init() tea.Cmd {
 func (m ReviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		if m.showingHelp {
+			if msg.String() == "?" || msg.Type == tea.KeyEsc {
+				m.showingHelp = false
+			}
+			return m, nil
+		}
+		if m.quitConfirm {
+			switch msg.String() {
+			case "y":
+				return m, tea.Quit
+			case "n", "N":
+				m.quitConfirm = false
+			}
+			return m, nil
+		}
 		if msg.String() == "q" {
+			if m.showingBack && !m.done {
+				m.quitConfirm = true
+				return m, nil
+			}
 			return m, tea.Quit
+		}
+		if msg.String() == "?" {
+			m.showingHelp = true
+			return m, nil
 		}
 		if m.done {
 			if msg.Type == tea.KeyEnter {
@@ -129,9 +227,16 @@ func (m ReviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.showingBack && m.rateFunc != nil && m.index < len(m.items) {
 				rating := int(msg.String()[0] - '0')
 				it := &m.items[m.index]
-				_, _, err := m.rateFunc(it, rating, time.Now())
+				prevCard := *it.Card
+				_, _, entry, err := m.rateFunc(it, rating, time.Now())
 				if err == nil {
 					m.ratingCounts[rating]++
+					m.undoable = &undoInfo{
+						entry:    entry,
+						cardPath: it.Card.FilePath,
+						card:     &prevCard,
+						rating:   rating,
+					}
 					m.index++
 					m.showingBack = false
 					m.previews = nil
@@ -141,7 +246,53 @@ func (m ReviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 			return m, nil
+		case "s":
+			if m.index < len(m.items) {
+				m.skippedCount++
+				m.items = append(m.items, m.items[m.index])
+				m.items = append(m.items[:m.index], m.items[m.index+1:]...)
+				m.showingBack = false
+				m.previews = nil
+			}
+			return m, nil
+		case "e":
+			if m.index < len(m.items) && m.items[m.index].Card.FilePath != "" {
+				path := m.items[m.index].Card.FilePath
+				return m, m.editorCmd(path)
+			}
+			return m, nil
+		case "u":
+			if m.undoable != nil && m.undoFunc != nil {
+				if err := m.undoFunc(m.undoable.entry, m.undoable.cardPath, m.undoable.card); err == nil {
+					m.ratingCounts[m.undoable.rating]--
+					m.index--
+					m.done = false
+					m.showingBack = false
+					m.previews = nil
+					m.items[m.index].Card = m.undoable.card
+					m.undoable = nil
+				}
+			}
+			return m, nil
 		}
+	}
+	switch msg := msg.(type) {
+	case EditFinishedMsg:
+		m.editErr = ""
+		if msg.Err != nil {
+			m.editErr = fmt.Sprintf("editor error: %v", msg.Err)
+			return m, nil
+		}
+		updated, err := m.cardReadFunc(msg.Path)
+		if err != nil {
+			m.editErr = fmt.Sprintf("error re-reading card: %v", err)
+			return m, nil
+		}
+		if updated != nil && m.index < len(m.items) {
+			m.items[m.index].Card = updated
+			m.editErr = ""
+		}
+		return m, nil
 	}
 	return m, nil
 }
@@ -152,6 +303,12 @@ func (m ReviewModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m ReviewModel) View() string {
 	if len(m.items) == 0 {
 		return "No cards in this deck.\nPress q to quit."
+	}
+	if m.showingHelp {
+		return renderHelpOverlay()
+	}
+	if m.quitConfirm {
+		return "Rating in progress - quit anyway? (y/N)"
 	}
 	if m.done {
 		return m.renderSummary()
@@ -169,6 +326,9 @@ func (m ReviewModel) View() string {
 	rendered, _ := m.renderer.Render(content)
 	if m.showingBack && len(m.previews) > 0 {
 		rendered += formatPreviews(m.previews)
+	}
+	if m.editErr != "" {
+		rendered += "\n" + lipgloss.NewStyle().Foreground(lipgloss.Color("1")).Render(m.editErr) + "\n"
 	}
 	return rendered
 }
@@ -275,5 +435,19 @@ func (m ReviewModel) renderSummary() string {
 		s += summaryLabel.Render("  Skipped:") + fmt.Sprintf(" %d\n", m.skippedCount)
 	}
 	s += summaryHint.Render("Press q or Enter to quit.")
+	return s
+}
+
+var helpTitle = lipgloss.NewStyle().Bold(true).MarginBottom(1)
+
+func renderHelpOverlay() string {
+	s := helpTitle.Render("Keybindings")
+	s += "  space/enter  flip card\n"
+	s += "  1-4          rate (again/hard/good/easy)\n"
+	s += "  e            edit card\n"
+	s += "  u            undo last rating\n"
+	s += "  s            skip card\n"
+	s += "  ?            toggle help\n"
+	s += "  q            quit\n"
 	return s
 }

--- a/internal/tui/review_test.go
+++ b/internal/tui/review_test.go
@@ -6,6 +6,7 @@
 package tui_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/card"
 	"github.com/jvcorredor/srs-tui/internal/deck"
 	"github.com/jvcorredor/srs-tui/internal/fsrs"
+	"github.com/jvcorredor/srs-tui/internal/store"
 	"github.com/jvcorredor/srs-tui/internal/tui"
 )
 
@@ -95,7 +97,7 @@ func TestReviewQuitOnQWhenDone(t *testing.T) {
 
 // fakeRateFunc is a stub RateFunc that returns fixed interval previews for
 // every rating, making tests deterministic and fast.
-func fakeRateFunc(item *deck.ReviewItem, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, error) {
+func fakeRateFunc(item *deck.ReviewItem, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, store.LogEntry, error) {
 	next := fsrs.CardState{State: fsrs.StateLearning, Stability: 1.5}
 	previews := []fsrs.IntervalPreview{
 		{Rating: 1, State: fsrs.StateLearning, Interval: 1 * time.Minute},
@@ -103,7 +105,15 @@ func fakeRateFunc(item *deck.ReviewItem, rating int, now time.Time) (fsrs.CardSt
 		{Rating: 3, State: fsrs.StateLearning, Interval: 10 * time.Minute},
 		{Rating: 4, State: fsrs.StateReview, Interval: 24 * time.Hour},
 	}
-	return next, previews, nil
+	entry := store.LogEntry{
+		Schema: 1,
+		TS:     now,
+		CardID: item.Card.ID,
+		Rating: rating,
+		Prev:   fsrs.CardState{State: fsrs.StateNew},
+		Next:   next,
+	}
+	return next, previews, entry, nil
 }
 
 // TestRatingKeyAdvancesCard checks that rating a flipped card moves the
@@ -314,6 +324,477 @@ func TestSummaryContainsStyledContent(t *testing.T) {
 		if !strings.Contains(view, want) {
 			t.Errorf("summary should contain %q, got:\n%s", want, view)
 		}
+	}
+}
+
+// TestSkipMovesCardToEndOfQueue verifies that pressing 's' moves the current
+// card to the end of the queue, increments the skipped counter, and shows
+// the next card's front side.
+func TestSkipMovesCardToEndOfQueue(t *testing.T) {
+	items := []deck.ReviewItem{
+		basicItem("1", "Q1", "A1"),
+		basicItem("2", "Q2", "A2"),
+		basicItem("3", "Q3", "A3"),
+	}
+	m := tui.NewReviewModel(items, fakeRateFunc)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	m = asReview(updated)
+
+	if m.ShowingBack() {
+		t.Error("after skipping, should show front of next card")
+	}
+	stats := m.Stats()
+	if stats.SkippedCount != 1 {
+		t.Errorf("after skipping 1 card, SkippedCount = %d, want 1", stats.SkippedCount)
+	}
+
+	view := m.View()
+	if !strings.Contains(view, "Q2") {
+		t.Errorf("after skipping Q1, should show Q2, got:\n%s", view)
+	}
+}
+
+// TestSkipOnLastCardWrapsToSkippedCard verifies that skipping the last
+// remaining card moves it to the end and the session continues with that
+// same card (now at the back of the queue).
+func TestSkipOnLastCardWrapsToSkippedCard(t *testing.T) {
+	items := []deck.ReviewItem{
+		basicItem("1", "Q1", "A1"),
+		basicItem("2", "Q2", "A2"),
+	}
+	m := tui.NewReviewModel(items, fakeRateFunc)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	m = asReview(updated)
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	m = asReview(updated)
+
+	stats := m.Stats()
+	if stats.SkippedCount != 2 {
+		t.Errorf("after skipping 2 cards, SkippedCount = %d, want 2", stats.SkippedCount)
+	}
+	if m.CurrentIndex() != 0 {
+		t.Errorf("after skipping all cards, index should wrap, got %d", m.CurrentIndex())
+	}
+}
+
+// TestSkipDoesNotPersist verifies that skipping does not call the rateFunc.
+func TestSkipDoesNotPersist(t *testing.T) {
+	called := false
+	rateFunc := func(item *deck.ReviewItem, rating int, now time.Time) (fsrs.CardState, []fsrs.IntervalPreview, store.LogEntry, error) {
+		called = true
+		return fsrs.CardState{}, nil, store.LogEntry{}, nil
+	}
+	items := []deck.ReviewItem{basicItem("1", "Q", "A"), basicItem("2", "Q2", "A2")}
+	m := tui.NewReviewModel(items, rateFunc)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	m = asReview(updated)
+
+	if called {
+		t.Error("skip should not call rateFunc")
+	}
+	stats := m.Stats()
+	if stats.TotalReviewed != 0 {
+		t.Error("skip should not increment TotalReviewed")
+	}
+}
+
+// TestSkipResetsFlipState verifies that skipping a card that has been
+// flipped to the back side resets to showing the front of the next card.
+func TestSkipResetsFlipState(t *testing.T) {
+	items := []deck.ReviewItem{
+		basicItem("1", "Q1", "A1"),
+		basicItem("2", "Q2", "A2"),
+	}
+	m := tui.NewReviewModel(items, fakeRateFunc)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	m = asReview(updated)
+	if !m.ShowingBack() {
+		t.Fatal("should be showing back before skip")
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	m = asReview(updated)
+
+	if m.ShowingBack() {
+		t.Error("after skipping a flipped card, should show front of next card")
+	}
+}
+
+// TestHelpOverlayTogglesOnQuestionMark verifies that pressing '?' shows
+// the help overlay listing all keybindings.
+func TestHelpOverlayTogglesOnQuestionMark(t *testing.T) {
+	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
+	m := tui.NewReviewModel(items, fakeRateFunc)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	m = asReview(updated)
+
+	view := m.View()
+	if !strings.Contains(view, "Keybindings") {
+		t.Errorf("help overlay should appear after pressing ?, got:\n%s", view)
+	}
+}
+
+// TestHelpOverlayDismissesOnQuestionMark verifies that pressing '?' again
+// hides the help overlay.
+func TestHelpOverlayDismissesOnQuestionMark(t *testing.T) {
+	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
+	m := tui.NewReviewModel(items, fakeRateFunc)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	m = asReview(updated)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	m = asReview(updated)
+
+	view := m.View()
+	if strings.Contains(view, "Keybindings") {
+		t.Errorf("help overlay should be dismissed after second press of ?, got:\n%s", view)
+	}
+}
+
+// TestHelpOverlayDismissesOnEsc verifies that pressing Escape hides the
+// help overlay.
+func TestHelpOverlayDismissesOnEsc(t *testing.T) {
+	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
+	m := tui.NewReviewModel(items, fakeRateFunc)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	m = asReview(updated)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = asReview(updated)
+
+	view := m.View()
+	if strings.Contains(view, "Keybindings") {
+		t.Errorf("help overlay should be dismissed after Esc, got:\n%s", view)
+	}
+}
+
+// TestHelpOverlayListsAllKeybindings verifies that the help overlay includes
+// all expected keybinding labels.
+func TestHelpOverlayListsAllKeybindings(t *testing.T) {
+	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
+	m := tui.NewReviewModel(items, fakeRateFunc)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'?'}})
+	m = asReview(updated)
+
+	view := m.View()
+	for _, want := range []string{"space/enter", "1-4", "e", "u", "s", "?", "q"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("help overlay should list keybinding %q, got:\n%s", want, view)
+		}
+	}
+}
+
+// TestQuitConfirmsWhenCardFlippedNotRated verifies that pressing 'q' while a
+// card is flipped (back showing) but not yet rated shows a confirmation prompt
+// instead of quitting immediately.
+func TestQuitConfirmsWhenCardFlippedNotRated(t *testing.T) {
+	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
+	m := tui.NewReviewModel(items, fakeRateFunc)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	m = asReview(updated)
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	m = asReview(updated)
+	if cmd != nil {
+		t.Error("q while flipped should not quit immediately, should show confirm prompt")
+	}
+	view := m.View()
+	if !strings.Contains(view, "quit anyway") {
+		t.Errorf("should show quit confirmation prompt, got:\n%s", view)
+	}
+}
+
+// TestQuitConfirmAcceptsY verifies that pressing 'y' at the quit confirmation
+// prompt exits the application.
+func TestQuitConfirmAcceptsY(t *testing.T) {
+	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
+	m := tui.NewReviewModel(items, fakeRateFunc)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	m = asReview(updated)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	m = asReview(updated)
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}})
+	if cmd == nil {
+		t.Error("y at quit confirmation should trigger tea.Quit")
+	}
+}
+
+// TestQuitConfirmRejectsN verifies that pressing 'n' at the quit confirmation
+// prompt dismisses the prompt and returns to the review.
+func TestQuitConfirmRejectsN(t *testing.T) {
+	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
+	m := tui.NewReviewModel(items, fakeRateFunc)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	m = asReview(updated)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	m = asReview(updated)
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	m = asReview(updated)
+	if cmd != nil {
+		t.Error("n at quit confirmation should not quit")
+	}
+	view := m.View()
+	if strings.Contains(view, "quit anyway") {
+		t.Errorf("n should dismiss quit prompt, got:\n%s", view)
+	}
+}
+
+// TestQuitNoConfirmOnFrontSide verifies that pressing 'q' on the front side
+// (not flipped) quits immediately without a confirmation prompt.
+func TestQuitNoConfirmOnFrontSide(t *testing.T) {
+	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
+	m := tui.NewReviewModel(items, fakeRateFunc)
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	if cmd == nil {
+		t.Error("q on front side should quit immediately")
+	}
+}
+
+// TestQuitNoConfirmAfterRating verifies that pressing 'q' after rating a card
+// (on the next card's front side) quits immediately.
+func TestQuitNoConfirmAfterRating(t *testing.T) {
+	items := []deck.ReviewItem{
+		basicItem("1", "Q1", "A1"),
+		basicItem("2", "Q2", "A2"),
+	}
+	m := tui.NewReviewModel(items, fakeRateFunc)
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	m = asReview(updated)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m = asReview(updated)
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	if cmd == nil {
+		t.Error("q after rating should quit immediately (on front side of next card)")
+	}
+}
+
+// TestEditOpensCurrentCardInEditor verifies that pressing 'e' invokes the
+// editor command with the current card's file path.
+func TestEditOpensCurrentCardInEditor(t *testing.T) {
+	editorCmd := func(path string) tea.Cmd {
+		return func() tea.Msg {
+			return tui.EditFinishedMsg{Path: path, Err: nil}
+		}
+	}
+	items := []deck.ReviewItem{
+		basicItem("1", "Q1", "A1"),
+	}
+	items[0].Card.FilePath = "/tmp/test-card.md"
+
+	m := tui.NewReviewModel(items, fakeRateFunc, tui.WithEditorCmd(editorCmd))
+
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	if cmd == nil {
+		t.Error("e should return a command to run the editor")
+	}
+}
+
+// TestEditReReadsCardFromDiskAfterEditor verifies that after the editor
+// command completes, the card is re-read from disk and the view reflects
+// the updated content.
+func TestEditReReadsCardFromDiskAfterEditor(t *testing.T) {
+	updatedFront := "Updated Q"
+	cardReadFunc := func(path string) (*card.Card, error) {
+		return &card.Card{Meta: card.Meta{ID: "1", Type: card.Basic}, Front: updatedFront, Back: "A1", FilePath: path}, nil
+	}
+
+	editorCmd := func(path string) tea.Cmd {
+		return func() tea.Msg {
+			return tui.EditFinishedMsg{Path: path, Err: nil}
+		}
+	}
+
+	items := []deck.ReviewItem{
+		basicItem("1", "Q1", "A1"),
+	}
+	items[0].Card.FilePath = "/tmp/test-card.md"
+
+	m := tui.NewReviewModel(items, fakeRateFunc, tui.WithEditorCmd(editorCmd), tui.WithCardReadFunc(cardReadFunc))
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	m = asReview(updated)
+
+	if cmd == nil {
+		t.Fatal("e should return a command")
+	}
+
+	msg := cmd()
+	updated, _ = m.Update(msg)
+	m = asReview(updated)
+
+	view := m.View()
+	if !strings.Contains(view, "Updated") {
+		t.Errorf("after editor, view should show updated content, got:\n%s", view)
+	}
+}
+
+// TestEditNonFatalErrorOnParseFailure verifies that when re-reading the card
+// from disk fails, the session continues with the in-memory copy and a
+// non-fatal error is shown.
+func TestEditNonFatalErrorOnParseFailure(t *testing.T) {
+	cardReadFunc := func(path string) (*card.Card, error) {
+		return nil, fmt.Errorf("parse error")
+	}
+
+	editorCmd := func(path string) tea.Cmd {
+		return func() tea.Msg {
+			return tui.EditFinishedMsg{Path: path, Err: nil}
+		}
+	}
+
+	items := []deck.ReviewItem{
+		basicItem("1", "Q1", "A1"),
+	}
+	items[0].Card.FilePath = "/tmp/test-card.md"
+
+	m := tui.NewReviewModel(items, fakeRateFunc, tui.WithEditorCmd(editorCmd), tui.WithCardReadFunc(cardReadFunc))
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'e'}})
+	m = asReview(updated)
+	msg := cmd()
+	updated, _ = m.Update(msg)
+	m = asReview(updated)
+
+	view := m.View()
+	if !strings.Contains(view, "Q1") {
+		t.Errorf("after parse failure, should still show original content, got:\n%s", view)
+	}
+	if !strings.Contains(view, "error") {
+		t.Errorf("should show non-fatal error message, got:\n%s", view)
+	}
+}
+
+// TestUndoReversesLastRating verifies that pressing 'u' after rating a card
+// decrements the index (returning to the undone card), decrements the rating
+// count, and calls the undoFunc.
+func TestUndoReversesLastRating(t *testing.T) {
+	undoCalled := false
+	undoFunc := func(entry store.LogEntry, cardPath string, c *card.Card) error {
+		undoCalled = true
+		return nil
+	}
+
+	items := []deck.ReviewItem{
+		basicItem("1", "Q1", "A1"),
+		basicItem("2", "Q2", "A2"),
+	}
+	m := tui.NewReviewModel(items, fakeRateFunc, tui.WithUndoFunc(undoFunc))
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	m = asReview(updated)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m = asReview(updated)
+
+	if m.CurrentIndex() != 1 {
+		t.Fatalf("after rating, index should be 1, got %d", m.CurrentIndex())
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+	m = asReview(updated)
+
+	if !undoCalled {
+		t.Error("undo should call undoFunc")
+	}
+	if m.CurrentIndex() != 0 {
+		t.Errorf("after undo, index should be 0, got %d", m.CurrentIndex())
+	}
+	stats := m.Stats()
+	if stats.RatingCounts[3] != 0 {
+		t.Errorf("after undo of Good rating, RatingCounts[3] should be 0, got %d", stats.RatingCounts[3])
+	}
+}
+
+// TestUndoIsNoOpWhenNoRatingDone verifies that pressing 'u' before any
+// rating has been made is a no-op.
+func TestUndoIsNoOpWhenNoRatingDone(t *testing.T) {
+	undoCalled := false
+	undoFunc := func(entry store.LogEntry, cardPath string, c *card.Card) error {
+		undoCalled = true
+		return nil
+	}
+
+	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
+	m := tui.NewReviewModel(items, fakeRateFunc, tui.WithUndoFunc(undoFunc))
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+	m = asReview(updated)
+
+	if undoCalled {
+		t.Error("undo before any rating should be a no-op")
+	}
+	if m.CurrentIndex() != 0 {
+		t.Error("undo before any rating should not change index")
+	}
+}
+
+// TestUndoIsSingleStepOnly verifies that pressing 'u' a second time after
+// already undoing once is a no-op.
+func TestUndoIsSingleStepOnly(t *testing.T) {
+	undoCount := 0
+	undoFunc := func(entry store.LogEntry, cardPath string, c *card.Card) error {
+		undoCount++
+		return nil
+	}
+
+	items := []deck.ReviewItem{
+		basicItem("1", "Q1", "A1"),
+		basicItem("2", "Q2", "A2"),
+	}
+	m := tui.NewReviewModel(items, fakeRateFunc, tui.WithUndoFunc(undoFunc))
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	m = asReview(updated)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m = asReview(updated)
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+	m = asReview(updated)
+
+	m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+
+	if undoCount != 1 {
+		t.Errorf("undo should only be possible once, got %d calls", undoCount)
+	}
+}
+
+// TestUndoReturnsToShowFrontSide verifies that after undoing a rating, the
+// undone card is shown on its front side (not back).
+func TestUndoReturnsToShowFrontSide(t *testing.T) {
+	undoFunc := func(entry store.LogEntry, cardPath string, c *card.Card) error {
+		return nil
+	}
+
+	items := []deck.ReviewItem{
+		basicItem("1", "Q1", "A1"),
+		basicItem("2", "Q2", "A2"),
+	}
+	m := tui.NewReviewModel(items, fakeRateFunc, tui.WithUndoFunc(undoFunc))
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
+	m = asReview(updated)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
+	m = asReview(updated)
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'u'}})
+	m = asReview(updated)
+
+	if m.ShowingBack() {
+		t.Error("after undo, should show front side of undone card")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Implements five review-screen keybindings from the PRD: `e` (edit card in `$EDITOR`), `u` (single-step undo of last rating), `s` (skip/defer card), `?` (help overlay), and `q` with mid-rating confirmation prompt
- Extends `RateFunc` to return `store.LogEntry` for undo tracking; adds `store.TruncateLastLog` and `cli.MakeUndoFunc` to reverse persisted ratings
- Editor command and card re-read are injectable via model options (`WithEditorCmd`, `WithCardReadFunc`, `WithUndoFunc`) for testability

Closes: #12

## Acceptance criteria progress

- [x] `e` suspends the TUI, runs `$EDITOR` on the current card's path, and resumes after editor exit
- [x] On editor exit, card is re-read from disk; parse failure shows non-fatal error and session continues with in-memory copy
- [x] `u` is only available immediately after a rating; it truncates the JSONL log line and rewrites the card frontmatter to prior FSRS state; undone card returns to front of queue
- [x] After undo, pressing `u` again is a no-op (single-step undo only)
- [x] `s` moves current card to end of in-memory queue without persisting anything
- [x] `?` toggles a help overlay listing all keybindings (space/enter, 1–4, e, u, s, ?, q)
- [x] `q` exits immediately on front side or after rating; when flipped but not rated, prompts "Rating in progress - quit anyway? (y/N)"
- [x] Help overlay is dismissable with `?` again or `esc`
- [x] Conflict policy: last-writer-wins; supported edit path is the in-app `e` keybinding