### PR TITLE
feat(config): validate config, warn on unknown keys, wire Glamour theme

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -181,10 +181,24 @@ func MakeUndoFunc(s *store.Store) tui.UndoFunc {
 
 // defaultReviewRun builds the review queue for deckDir, opens the interactive
 // Bubble Tea review session, and persists ratings via MakeRateFunc.
-func defaultReviewRun(deckDir string) error {
-	cfg, _ := config.Load(paths.ConfigHome())
+func loadConfig() (*config.Config, error) {
+	cfg, warnings, err := config.Load(paths.ConfigHome())
+	if err != nil {
+		return nil, err
+	}
 	if cfg == nil {
 		cfg = config.Defaults()
+	}
+	for _, w := range warnings {
+		fmt.Fprintln(os.Stderr, w)
+	}
+	return cfg, nil
+}
+
+func defaultReviewRun(deckDir string) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
 	}
 
 	now := time.Now()
@@ -207,6 +221,7 @@ func defaultReviewRun(deckDir string) error {
 	m := tui.NewReviewModel(items, rateFunc,
 		tui.WithEditorCmd(tui.EditorExecCmd),
 		tui.WithUndoFunc(undoFunc),
+		tui.WithRenderStyle(cfg.Render.Style),
 	)
 	p := tea.NewProgram(m, tea.WithAltScreen())
 	_, err = p.Run()
@@ -222,9 +237,9 @@ func defaultPickerRun(decksRoot string) error {
 		return fmt.Errorf("picker: %w", err)
 	}
 
-	cfg, _ := config.Load(paths.ConfigHome())
-	if cfg == nil {
-		cfg = config.Defaults()
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
 	}
 
 	now := time.Now()
@@ -255,6 +270,7 @@ func defaultPickerRun(decksRoot string) error {
 		return tui.NewReviewModel(items, rateFunc,
 			tui.WithEditorCmd(tui.EditorExecCmd),
 			tui.WithUndoFunc(undoFunc),
+			tui.WithRenderStyle(cfg.Render.Style),
 		), nil
 	}
 
@@ -478,6 +494,11 @@ func ExecuteWithArgs(args []string) int {
 	if err != nil {
 		var usageErr *UsageError
 		if errors.As(err, &usageErr) {
+			return 2
+		}
+		var fieldErr config.FieldError
+		if errors.As(err, &fieldErr) {
+			_, _ = fmt.Fprintln(os.Stderr, fieldErr.Error())
 			return 2
 		}
 		return 1

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/jvcorredor/srs-tui/internal/card"
 	"github.com/jvcorredor/srs-tui/internal/cli"
+	"github.com/jvcorredor/srs-tui/internal/config"
 	"github.com/jvcorredor/srs-tui/internal/deck"
 	"github.com/jvcorredor/srs-tui/internal/fsrs"
 	"github.com/jvcorredor/srs-tui/internal/store"
@@ -903,5 +904,27 @@ func TestDecksCommandEmptyRootPrintsNothing(t *testing.T) {
 
 	if stdout.String() != "" {
 		t.Errorf("output should be empty for empty root, got %q", stdout.String())
+	}
+}
+
+func TestConfigValidationErrorReturnsExitCode2(t *testing.T) {
+	cli.SetOutput(io.Discard)
+	cli.SetReviewRun(func(deckDir string) error {
+		return config.FieldError{File: "/test/config.toml", Key: "review.new_per_day", Reason: "incompatible types"}
+	})
+	code := cli.ExecuteWithArgs([]string{"review", "somedeck"})
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2 for config validation error", code)
+	}
+}
+
+func TestConfigNegativeNewPerDayReturnsExitCode2(t *testing.T) {
+	cli.SetOutput(io.Discard)
+	cli.SetReviewRun(func(deckDir string) error {
+		return config.FieldError{File: "/test/config.toml", Key: "review.new_per_day", Reason: "must be non-negative, got -5"}
+	})
+	code := cli.ExecuteWithArgs([]string{"review", "somedeck"})
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2 for negative new_per_day", code)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 	"github.com/jvcorredor/srs-tui/internal/paths"
@@ -36,6 +37,17 @@ type RenderConfig struct {
 	Style string `toml:"style"`
 }
 
+// FieldError represents a validation error for a specific config key.
+type FieldError struct {
+	File   string
+	Key    string
+	Reason string
+}
+
+func (e FieldError) Error() string {
+	return fmt.Sprintf("%s: %s: %s", e.File, e.Key, e.Reason)
+}
+
 // Config is the top-level configuration aggregate.
 type Config struct {
 	Paths  PathsConfig  `toml:"paths"`
@@ -57,34 +69,72 @@ func Defaults() *Config {
 			Command: "",
 		},
 		Render: RenderConfig{
-			Style: "dark",
+			Style: "auto",
 		},
 	}
 }
 
+// knownKeys lists every valid dotted key in the v1 config surface.
+var knownKeys = map[string]bool{
+	"paths":              true,
+	"paths.decks_root":   true,
+	"review":             true,
+	"review.new_per_day": true,
+	"editor":             true,
+	"editor.command":     true,
+	"render":             true,
+	"render.style":       true,
+}
+
+var glamourStyles = map[string]bool{
+	"auto":  true,
+	"dark":  true,
+	"light": true,
+	"notty": true,
+	"pink":  true,
+}
+
 // Load reads config.toml from <configDir>/srs and returns the merged
-// result.  Missing files are treated as an empty config, so defaults
-// are always preserved.  Tilde characters in DecksRoot are expanded
-// to the user's home directory.
-func Load(configDir string) (*Config, error) {
+// result along with any warnings for unknown keys.  Missing files are
+// treated as an empty config, so defaults are always preserved.  Tilde
+// characters in DecksRoot are expanded to the user's home directory.
+func Load(configDir string) (*Config, []string, error) {
 	cfg := Defaults()
 	p := filepath.Join(configDir, "srs", "config.toml")
 
 	if _, err := os.Stat(p); os.IsNotExist(err) {
-		return cfg, nil
+		return cfg, nil, nil
 	}
 
-	if _, err := toml.DecodeFile(p, cfg); err != nil {
-		return nil, err
+	meta, err := toml.DecodeFile(p, cfg)
+	if err != nil {
+		return nil, nil, wrapDecodeError(err, p)
+	}
+
+	var warnings []string
+	for _, key := range meta.Keys() {
+		dotted := strings.Join(key, ".")
+		if !knownKeys[dotted] {
+			warnings = append(warnings, fmt.Sprintf("warning: unknown config key %q in %s", dotted, p))
+		}
 	}
 
 	cfg.Paths.DecksRoot = paths.ExpandHome(cfg.Paths.DecksRoot)
 
-	if cfg.Review.NewPerDay < 0 {
-		return nil, fmt.Errorf("config: review.new_per_day must be non-negative, got %d", cfg.Review.NewPerDay)
+	if !glamourStyles[cfg.Render.Style] {
+		warnings = append(warnings, fmt.Sprintf("warning: unknown render.style %q in %s; falling back to %q", cfg.Render.Style, p, "auto"))
+		cfg.Render.Style = "auto"
 	}
 
-	return cfg, nil
+	if cfg.Review.NewPerDay < 0 {
+		return nil, warnings, FieldError{
+			File:   p,
+			Key:    "review.new_per_day",
+			Reason: fmt.Sprintf("must be non-negative, got %d", cfg.Review.NewPerDay),
+		}
+	}
+
+	return cfg, warnings, nil
 }
 
 // DefaultConfigContent returns the text embedded in a newly scaffolded
@@ -100,6 +150,27 @@ func DefaultConfigContent() string {
 # command = ""       # Editor for card creation (empty = $EDITOR or vi)
 
 # [render]
-# style = "dark"     # dark or light
+# style = "auto"     # auto, dark, light, notty, pink
 `
+}
+
+func wrapDecodeError(err error, file string) error {
+	s := err.Error()
+	prefix := `(last key "`
+	i := strings.Index(s, prefix)
+	if i < 0 {
+		return err
+	}
+	i += len(prefix)
+	j := strings.Index(s[i:], `"`)
+	if j < 0 {
+		return err
+	}
+	key := s[i : i+j]
+	reasonStart := strings.Index(s[i+j:], "): ")
+	if reasonStart < 0 {
+		return err
+	}
+	reason := s[i+j+reasonStart+3:]
+	return FieldError{File: file, Key: key, Reason: reason}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,18 +1,17 @@
-// Package config_test contains unit tests for the config loader.
 package config_test
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jvcorredor/srs-tui/internal/config"
 )
 
-// TestLoadReturnsDefaultsWhenFileAbsent confirms that Load returns the
-// built-in defaults when no config.toml exists.
 func TestLoadReturnsDefaultsWhenFileAbsent(t *testing.T) {
-	cfg, err := config.Load(t.TempDir())
+	cfg, warnings, err := config.Load(t.TempDir())
 	if err != nil {
 		t.Fatalf("Load() error: %v", err)
 	}
@@ -30,10 +29,21 @@ func TestLoadReturnsDefaultsWhenFileAbsent(t *testing.T) {
 	if cfg.Render.Style != defaults.Render.Style {
 		t.Errorf("Render.Style = %q, want %q", cfg.Render.Style, defaults.Render.Style)
 	}
+	if len(warnings) != 0 {
+		t.Errorf("warnings = %v, want empty", warnings)
+	}
 }
 
-// TestLoadParsesV1KeysFromConfigToml verifies that every documented config
-// key is read correctly from a real TOML file.
+func TestLoadDefaultRenderStyleIsAuto(t *testing.T) {
+	cfg, _, err := config.Load(t.TempDir())
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.Render.Style != "auto" {
+		t.Errorf("Render.Style = %q, want %q", cfg.Render.Style, "auto")
+	}
+}
+
 func TestLoadParsesV1KeysFromConfigToml(t *testing.T) {
 	dir := t.TempDir()
 	srsDir := filepath.Join(dir, "srs")
@@ -57,7 +67,7 @@ style = "light"
 		t.Fatal(err)
 	}
 
-	cfg, err := config.Load(dir)
+	cfg, warnings, err := config.Load(dir)
 	if err != nil {
 		t.Fatalf("Load() error: %v", err)
 	}
@@ -74,10 +84,11 @@ style = "light"
 	if cfg.Render.Style != "light" {
 		t.Errorf("Render.Style = %q, want %q", cfg.Render.Style, "light")
 	}
+	if len(warnings) != 0 {
+		t.Errorf("warnings = %v, want empty", warnings)
+	}
 }
 
-// TestLoadPartialConfigKeepsDefaults checks that omitted sections fall back
-// to defaults rather than zero values.
 func TestLoadPartialConfigKeepsDefaults(t *testing.T) {
 	dir := t.TempDir()
 	srsDir := filepath.Join(dir, "srs")
@@ -92,7 +103,7 @@ new_per_day = 5
 		t.Fatal(err)
 	}
 
-	cfg, err := config.Load(dir)
+	cfg, _, err := config.Load(dir)
 	if err != nil {
 		t.Fatalf("Load() error: %v", err)
 	}
@@ -109,8 +120,6 @@ new_per_day = 5
 	}
 }
 
-// TestLoadExpandsTildeInDecksRoot ensures that a leading "~" in decks_root
-// is expanded to the user's home directory.
 func TestLoadExpandsTildeInDecksRoot(t *testing.T) {
 	dir := t.TempDir()
 	srsDir := filepath.Join(dir, "srs")
@@ -125,7 +134,7 @@ decks_root = "~/my-decks"
 		t.Fatal(err)
 	}
 
-	cfg, err := config.Load(dir)
+	cfg, _, err := config.Load(dir)
 	if err != nil {
 		t.Fatalf("Load() error: %v", err)
 	}
@@ -137,8 +146,6 @@ decks_root = "~/my-decks"
 	}
 }
 
-// TestLoadRejectsNegativeNewPerDay verifies that Load returns an error when
-// new_per_day is set to a negative value in the config file.
 func TestLoadRejectsNegativeNewPerDay(t *testing.T) {
 	dir := t.TempDir()
 	srsDir := filepath.Join(dir, "srs")
@@ -153,8 +160,121 @@ new_per_day = -5
 		t.Fatal(err)
 	}
 
-	_, err := config.Load(dir)
+	_, _, err := config.Load(dir)
 	if err == nil {
 		t.Fatal("Load() should return error for negative new_per_day")
+	}
+}
+
+func TestLoadTypeMismatchReturnsFieldError(t *testing.T) {
+	dir := t.TempDir()
+	srsDir := filepath.Join(dir, "srs")
+	if err := os.MkdirAll(srsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tomlContent := `[review]
+new_per_day = "not-a-number"
+`
+	if err := os.WriteFile(filepath.Join(srsDir, "config.toml"), []byte(tomlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := config.Load(dir)
+	if err == nil {
+		t.Fatal("Load() should return error for type mismatch")
+	}
+
+	var fe config.FieldError
+	if !errors.As(err, &fe) {
+		t.Fatalf("error should be FieldError, got %T: %v", err, err)
+	}
+	if fe.Key != "review.new_per_day" {
+		t.Errorf("FieldError.Key = %q, want %q", fe.Key, "review.new_per_day")
+	}
+	if fe.File == "" {
+		t.Error("FieldError.File should not be empty")
+	}
+	if fe.Reason == "" {
+		t.Error("FieldError.Reason should not be empty")
+	}
+}
+
+func TestLoadUnknownKeyProducesWarning(t *testing.T) {
+	dir := t.TempDir()
+	srsDir := filepath.Join(dir, "srs")
+	if err := os.MkdirAll(srsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tomlContent := `[paths]
+decks_root = "/valid"
+
+[review]
+new_per_day = 10
+
+[typo]
+some_key = "oops"
+`
+	if err := os.WriteFile(filepath.Join(srsDir, "config.toml"), []byte(tomlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, warnings, err := config.Load(dir)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("Load() returned nil config for unknown keys")
+	}
+	if cfg.Paths.DecksRoot != "/valid" {
+		t.Errorf("Paths.DecksRoot = %q, want %q", cfg.Paths.DecksRoot, "/valid")
+	}
+
+	if len(warnings) == 0 {
+		t.Fatal("Load() returned no warnings for unknown keys")
+	}
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "typo.some_key") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("warnings = %v, want warning containing %q", warnings, "typo.some_key")
+	}
+}
+
+func TestLoadInvalidRenderStyleFallsBackToAuto(t *testing.T) {
+	dir := t.TempDir()
+	srsDir := filepath.Join(dir, "srs")
+	if err := os.MkdirAll(srsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tomlContent := `[render]
+style = "neon"
+`
+	if err := os.WriteFile(filepath.Join(srsDir, "config.toml"), []byte(tomlContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, warnings, err := config.Load(dir)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.Render.Style != "auto" {
+		t.Errorf("Render.Style = %q, want %q (fallback)", cfg.Render.Style, "auto")
+	}
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "render.style") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("warnings = %v, want warning containing %q", warnings, "render.style")
 	}
 }

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -157,7 +157,7 @@ func TestPickerSelectTransitionsToReviewModel(t *testing.T) {
 	var modelReturned tea.Model
 	m := tui.NewPickerModel(decks, func(e tui.DeckEntry) (tea.Model, tea.Cmd) {
 		items := []deck.ReviewItem{pickerBasicItem("1", "Q", "A")}
-		review := tui.NewReviewModel(items, pickerFakeRateFunc)
+		review := tui.NewReviewModel(items, pickerFakeRateFunc, tui.WithRenderStyle("dark"))
 		modelReturned = review
 		return review, nil
 	})

--- a/internal/tui/review.go
+++ b/internal/tui/review.go
@@ -41,6 +41,7 @@ type ReviewModel struct {
 	showingHelp  bool
 	quitConfirm  bool
 	renderer     *glamour.TermRenderer
+	renderStyle  string
 	rateFunc     RateFunc
 	previews     []fsrs.IntervalPreview
 	done         bool
@@ -85,6 +86,15 @@ func WithUndoFunc(fn UndoFunc) modelOption {
 	return func(m *ReviewModel) { m.undoFunc = fn }
 }
 
+// WithRenderStyle sets the Glamour style used to render card bodies.
+func WithRenderStyle(style string) modelOption {
+	return func(m *ReviewModel) {
+		if style != "" {
+			m.renderStyle = style
+		}
+	}
+}
+
 // EditFinishedMsg is sent when the external editor finishes editing a card.
 type EditFinishedMsg struct {
 	Path string
@@ -93,12 +103,12 @@ type EditFinishedMsg struct {
 
 // NewReviewModel creates a ReviewModel for the given review items. The
 // rateFunc is invoked each time the user presses a rating key (1–4) while
-// the back side is visible.
+// the back side is visible. Optional model options configure editor, undo,
+// and render style.
 func NewReviewModel(items []deck.ReviewItem, rateFunc RateFunc, opts ...modelOption) ReviewModel {
-	r, _ := glamour.NewTermRenderer(glamour.WithStandardStyle("dark"))
 	m := ReviewModel{
 		items:        items,
-		renderer:     r,
+		renderStyle:  "auto",
 		rateFunc:     rateFunc,
 		ratingCounts: make(map[int]int),
 	}
@@ -111,6 +121,8 @@ func NewReviewModel(items []deck.ReviewItem, rateFunc RateFunc, opts ...modelOpt
 	if m.cardReadFunc == nil {
 		m.cardReadFunc = card.ParseFile
 	}
+	r, _ := glamour.NewTermRenderer(glamour.WithStandardStyle(m.renderStyle))
+	m.renderer = r
 	return m
 }
 
@@ -129,6 +141,11 @@ func EditorExecCmd(path string) tea.Cmd {
 	return tea.ExecProcess(c, func(err error) tea.Msg {
 		return EditFinishedMsg{Path: path, Err: err}
 	})
+}
+
+// RenderStyle returns the Glamour style name used to render card bodies.
+func (m ReviewModel) RenderStyle() string {
+	return m.renderStyle
 }
 
 // ShowingBack reports whether the answer side of the current card is visible.

--- a/internal/tui/review_test.go
+++ b/internal/tui/review_test.go
@@ -44,7 +44,7 @@ func clozeItem(id, body, group string) deck.ReviewItem {
 // current card.
 func TestReviewFlipOnSpace(t *testing.T) {
 	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
-	m := tui.NewReviewModel(items, nil)
+	m := tui.NewReviewModel(items, nil, tui.WithRenderStyle("dark"))
 	if m.ShowingBack() {
 		t.Error("should start showing front")
 	}
@@ -57,7 +57,7 @@ func TestReviewFlipOnSpace(t *testing.T) {
 // TestReviewFlipOnEnter verifies that pressing Enter also reveals the back.
 func TestReviewFlipOnEnter(t *testing.T) {
 	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
-	m := tui.NewReviewModel(items, nil)
+	m := tui.NewReviewModel(items, nil, tui.WithRenderStyle("dark"))
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	if !asReview(updated).ShowingBack() {
 		t.Error("enter should flip to back")
@@ -67,7 +67,7 @@ func TestReviewFlipOnEnter(t *testing.T) {
 // TestReviewQuitOnQ verifies that pressing 'q' returns a tea.Quit command.
 func TestReviewQuitOnQ(t *testing.T) {
 	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
-	m := tui.NewReviewModel(items, nil)
+	m := tui.NewReviewModel(items, nil, tui.WithRenderStyle("dark"))
 	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
 	if cmd == nil {
 		t.Error("q should trigger quit")
@@ -78,7 +78,7 @@ func TestReviewQuitOnQ(t *testing.T) {
 // session is complete (m.done == true).
 func TestReviewQuitOnQWhenDone(t *testing.T) {
 	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
-	m := tui.NewReviewModel(items, fakeRateFunc)
+	m := tui.NewReviewModel(items, fakeRateFunc, tui.WithRenderStyle("dark"))
 	// Flip and rate the only card so the session ends.
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
 	m = asReview(updated)
@@ -123,7 +123,7 @@ func TestRatingKeyAdvancesCard(t *testing.T) {
 		basicItem("1", "Q1", "A1"),
 		basicItem("2", "Q2", "A2"),
 	}
-	m := tui.NewReviewModel(items, fakeRateFunc)
+	m := tui.NewReviewModel(items, fakeRateFunc, tui.WithRenderStyle("dark"))
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
 	m = asReview(updated)
 
@@ -141,7 +141,7 @@ func TestRatingKeyAdvancesCard(t *testing.T) {
 // includes preview labels (Again, Hard, etc.) once the card is flipped.
 func TestRatingKeyShowsIntervalPreviewsOnBack(t *testing.T) {
 	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
-	m := tui.NewReviewModel(items, fakeRateFunc)
+	m := tui.NewReviewModel(items, fakeRateFunc, tui.WithRenderStyle("dark"))
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
 	m = asReview(updated)
 
@@ -160,7 +160,7 @@ func TestAllFourRatingKeysAccepted(t *testing.T) {
 		basicItem("3", "Q3", "A3"),
 		basicItem("4", "Q4", "A4"),
 	}
-	m := tui.NewReviewModel(items, fakeRateFunc)
+	m := tui.NewReviewModel(items, fakeRateFunc, tui.WithRenderStyle("dark"))
 
 	for _, key := range []rune{'1', '2', '3', '4'} {
 		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
@@ -179,7 +179,7 @@ func TestClozeQuestionHidesActiveGroup(t *testing.T) {
 	items := []deck.ReviewItem{
 		clozeItem("1", "The {{c1::capital::city}} of France is {{c2::Paris}}.", "c1"),
 	}
-	m := tui.NewReviewModel(items, nil)
+	m := tui.NewReviewModel(items, nil, tui.WithRenderStyle("dark"))
 	view := m.View()
 	if strings.Contains(view, "capital") {
 		t.Errorf("question should hide active group c1, got:\n%s", view)
@@ -198,7 +198,7 @@ func TestClozeAnswerRevealsActiveGroup(t *testing.T) {
 	items := []deck.ReviewItem{
 		clozeItem("1", "The {{c1::capital::city}} of France is {{c2::Paris}}.", "c1"),
 	}
-	m := tui.NewReviewModel(items, nil)
+	m := tui.NewReviewModel(items, nil, tui.WithRenderStyle("dark"))
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
 	m = asReview(updated)
 	view := m.View()
@@ -217,7 +217,7 @@ func TestClozeAnswerRevealsActiveGroup(t *testing.T) {
 // appropriate count in the session statistics.
 func TestRatingTracksCounts(t *testing.T) {
 	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
-	m := tui.NewReviewModel(items, fakeRateFunc)
+	m := tui.NewReviewModel(items, fakeRateFunc, tui.WithRenderStyle("dark"))
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
 	m = asReview(updated)
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
@@ -240,7 +240,7 @@ func TestSummaryShowsTotalAndBreakdown(t *testing.T) {
 		basicItem("3", "Q3", "A3"),
 		basicItem("4", "Q4", "A4"),
 	}
-	m := tui.NewReviewModel(items, fakeRateFunc)
+	m := tui.NewReviewModel(items, fakeRateFunc, tui.WithRenderStyle("dark"))
 	keys := []rune{'1', '2', '3', '4'}
 	for _, key := range keys {
 		updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
@@ -261,7 +261,7 @@ func TestSummaryShowsTotalAndBreakdown(t *testing.T) {
 // emits tea.Quit, just like pressing q.
 func TestSummaryEnterQuits(t *testing.T) {
 	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
-	m := tui.NewReviewModel(items, fakeRateFunc)
+	m := tui.NewReviewModel(items, fakeRateFunc, tui.WithRenderStyle("dark"))
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
 	m = asReview(updated)
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
@@ -276,7 +276,7 @@ func TestSummaryEnterQuits(t *testing.T) {
 // includes a Skipped count only when at least one card was skipped.
 func TestSummarySkippedCardsShownWhenNonZero(t *testing.T) {
 	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
-	m := tui.NewReviewModel(items, fakeRateFunc)
+	m := tui.NewReviewModel(items, fakeRateFunc, tui.WithRenderStyle("dark"))
 	m.Skip()
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
 	m = asReview(updated)
@@ -292,7 +292,7 @@ func TestSummarySkippedCardsShownWhenNonZero(t *testing.T) {
 // the Skipped line when no cards were skipped.
 func TestSummarySkippedCardsHiddenWhenZero(t *testing.T) {
 	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
-	m := tui.NewReviewModel(items, fakeRateFunc)
+	m := tui.NewReviewModel(items, fakeRateFunc, tui.WithRenderStyle("dark"))
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
 	m = asReview(updated)
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'3'}})
@@ -310,7 +310,7 @@ func TestSummaryContainsStyledContent(t *testing.T) {
 		basicItem("1", "Q1", "A1"),
 		basicItem("2", "Q2", "A2"),
 	}
-	m := tui.NewReviewModel(items, fakeRateFunc)
+	m := tui.NewReviewModel(items, fakeRateFunc, tui.WithRenderStyle("dark"))
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeySpace})
 	m = asReview(updated)
 	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'1'}})
@@ -804,12 +804,28 @@ func TestClozeNoHintShowsEllipsis(t *testing.T) {
 	items := []deck.ReviewItem{
 		clozeItem("1", "The answer is {{c1::42}}.", "c1"),
 	}
-	m := tui.NewReviewModel(items, nil)
+	m := tui.NewReviewModel(items, nil, tui.WithRenderStyle("dark"))
 	view := m.View()
 	if strings.Contains(view, "42") {
 		t.Errorf("question should hide answer 42, got:\n%s", view)
 	}
 	if !strings.Contains(view, "...") {
 		t.Errorf("question should show placeholder containing '...', got:\n%s", view)
+	}
+}
+
+func TestReviewModelUsesProvidedStyle(t *testing.T) {
+	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
+	m := tui.NewReviewModel(items, nil, tui.WithRenderStyle("light"))
+	if m.RenderStyle() != "light" {
+		t.Errorf("RenderStyle() = %q, want %q", m.RenderStyle(), "light")
+	}
+}
+
+func TestReviewModelDefaultStyleIsAuto(t *testing.T) {
+	items := []deck.ReviewItem{basicItem("1", "Q", "A")}
+	m := tui.NewReviewModel(items, nil)
+	if m.RenderStyle() != "auto" {
+		t.Errorf("RenderStyle() = %q, want %q (default)", m.RenderStyle(), "auto")
 	}
 }


### PR DESCRIPTION
## Summary

- Config validation reports type mismatches as `FieldError` with file path, dotted key, and reason; validation errors cause exit code 2
- Unknown config keys produce non-fatal warnings to stderr (format: `warning: unknown config key "<key>" in <path>`)
- `render.style` selects the Glamour theme used for card bodies (default `auto`); invalid values fall back to `auto` with a warning
- `NewReviewModel` now accepts a `style` parameter, wired from `cfg.Render.Style` in CLI

Closes: #13