### PR TITLE
feat(slug): add Slugify utility (internal/slug)

### DIFF
--- a/internal/slug/slug.go
+++ b/internal/slug/slug.go
@@ -1,0 +1,36 @@
+// Package slug normalizes human-readable names into filesystem-safe
+// identifiers. It is the shared foundation used by both the CLI commands and
+// the TUI when auto-slugifying deck and card names before constructing paths.
+package slug
+
+import "strings"
+
+// Slugify converts input into a filesystem-safe identifier: it lowercases the
+// input, replaces every run of non-alphanumeric runes (spaces, punctuation,
+// unicode letters, etc.) with a single hyphen, and strips leading and trailing
+// hyphens. Only ASCII [a-z0-9] runes are preserved; everything else acts as a
+// separator. Input that contains no alphanumeric runes yields an empty string.
+func Slugify(input string) string {
+	var b strings.Builder
+	b.Grow(len(input))
+
+	// pendingHyphen records that a separator run is in progress. Starting it
+	// true makes leading separators collapse away; a hyphen is only emitted
+	// once an alphanumeric rune has actually been written.
+	pendingHyphen := true
+
+	for _, r := range strings.ToLower(input) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			if pendingHyphen && b.Len() > 0 {
+				b.WriteByte('-')
+			}
+			b.WriteRune(r)
+			pendingHyphen = false
+		default:
+			pendingHyphen = true
+		}
+	}
+
+	return b.String()
+}

--- a/internal/slug/slug_test.go
+++ b/internal/slug/slug_test.go
@@ -1,0 +1,66 @@
+// Package slug_test contains unit tests for the Slugify normalizer.
+package slug_test
+
+import (
+	"testing"
+
+	"github.com/jvcorredor/srs-tui/internal/slug"
+)
+
+// TestSlugify exercises every normalization rule and edge case.
+func TestSlugify(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty string", "", ""},
+		{"already a slug", "hello-world", "hello-world"},
+		{"lowercases", "Hello World", "hello-world"},
+		{"all uppercase", "SPANISH VERBS", "spanish-verbs"},
+		{"spaces to hyphens", "my deck name", "my-deck-name"},
+		{"punctuation to hyphens", "what's up?", "what-s-up"},
+		{"collapses multiple hyphens", "a---b", "a-b"},
+		{"collapses mixed separators", "a _ - . b", "a-b"},
+		{"strips leading hyphens", "---hello", "hello"},
+		{"strips trailing hyphens", "hello---", "hello"},
+		{"strips leading and trailing", "  hello world  ", "hello-world"},
+		{"keeps digits", "deck 42", "deck-42"},
+		{"all special chars", "!@#$%^&*()", ""},
+		{"only spaces", "   ", ""},
+		{"only hyphens", "------", ""},
+		{"unicode letters become separators", "café münchen", "caf-m-nchen"},
+		{"unicode emoji become separators", "deck 🎴 one", "deck-one"},
+		{"accented run collapses", "résumé", "r-sum"},
+		{"underscores treated as separators", "snake_case_name", "snake-case-name"},
+		{"tabs and newlines", "line one\tline\ntwo", "line-one-line-two"},
+		{"single character", "A", "a"},
+		{"leading digit preserved", "3 blind mice", "3-blind-mice"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := slug.Slugify(tt.input); got != tt.want {
+				t.Errorf("Slugify(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSlugifyIsIdempotent verifies that slugifying an already-slugified value
+// returns it unchanged, which callers rely on when re-normalizing stored names.
+func TestSlugifyIsIdempotent(t *testing.T) {
+	inputs := []string{
+		"",
+		"hello-world",
+		"deck-42",
+		"a-b-c",
+	}
+	for _, in := range inputs {
+		once := slug.Slugify(in)
+		twice := slug.Slugify(once)
+		if once != twice {
+			t.Errorf("Slugify not idempotent for %q: once=%q twice=%q", in, once, twice)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds the `internal/slug/` package with a single exported `Slugify(input string) string` function that normalizes deck and card names into filesystem-safe identifiers. This is the shared foundation for auto-slugifying names in both CLI commands and the TUI (parent #59).

## Rules

- Lowercases the input
- Replaces runs of non-alphanumeric runes (spaces, punctuation, unicode letters, emoji) with a single hyphen
- Collapses consecutive hyphens into one
- Strips leading and trailing hyphens
- Only ASCII `[a-z0-9]` runes are preserved; everything else acts as a separator, so output is deterministic and filesystem-safe

## Edge cases

- Empty string → empty string
- All-special-chars input → empty string
- Unicode input does not panic — non-ASCII letters/emoji are treated as separators (`café münchen` → `caf-m-nchen`)

## Testing

- `go test -cover ./internal/slug/` — 100.0% statement coverage
- `go vet` and `gofmt` clean
- Table-driven tests cover every rule plus an idempotency check

Closes: #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)