### PR TITLE
feat(cli): add deck subcommand with create and list

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,5 +1,5 @@
 // Package cli implements the command-line interface for srs-tui.
-// It defines the cobra commands (review, new, version, init) and
+// It defines the cobra commands (review, new, deck, version, init) and
 // the glue functions that wire the terminal UI, card storage, and
 // scheduling logic together.
 package cli
@@ -23,6 +23,7 @@ import (
 	"github.com/jvcorredor/srs-tui/internal/deck"
 	"github.com/jvcorredor/srs-tui/internal/fsrs"
 	"github.com/jvcorredor/srs-tui/internal/paths"
+	"github.com/jvcorredor/srs-tui/internal/slug"
 	"github.com/jvcorredor/srs-tui/internal/store"
 	"github.com/jvcorredor/srs-tui/internal/tui"
 	"github.com/jvcorredor/srs-tui/internal/version"
@@ -297,6 +298,7 @@ func NewRootCmd() *cobra.Command {
 	root.AddCommand(newReviewCmd())
 	root.AddCommand(newNewCmd())
 	root.AddCommand(newInitCmd())
+	root.AddCommand(newDeckCmd())
 	root.AddCommand(newDecksCmd())
 	return root
 }
@@ -413,10 +415,52 @@ func newInitCmd() *cobra.Command {
 	return cmd
 }
 
-func newDecksCmd() *cobra.Command {
+// newDeckCmd creates the "deck" parent command grouping deck-management
+// subcommands (create, list).
+func newDeckCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "deck",
+		Short: "Manage decks",
+	}
+	cmd.AddCommand(newDeckCreateCmd())
+	cmd.AddCommand(newDeckListCmd("list"))
+	return cmd
+}
+
+// newDeckCreateCmd creates the "deck create <name>" command, which creates a
+// new deck directory under the decks root using the slugified name.
+func newDeckCreateCmd() *cobra.Command {
 	var decksRoot string
 	cmd := &cobra.Command{
-		Use:   "decks",
+		Use:   "create <name>",
+		Short: "Create a new deck directory",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return &UsageError{msg: fmt.Sprintf("accepts 1 arg(s), received %d", len(args))}
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return RunDeckCreate(paths.DecksRoot(decksRoot), args[0], cmd.OutOrStdout())
+		},
+		SilenceUsage: true,
+	}
+	cmd.Flags().StringVar(&decksRoot, "decks-root", "", "root directory for decks")
+	return cmd
+}
+
+// newDecksCmd creates the top-level "decks" command, kept as a
+// backward-compatible alias for "deck list".
+func newDecksCmd() *cobra.Command {
+	return newDeckListCmd("decks")
+}
+
+// newDeckListCmd builds a deck-listing command under the given name. It backs
+// both "deck list" and the backward-compatible top-level "decks" command.
+func newDeckListCmd(use string) *cobra.Command {
+	var decksRoot string
+	cmd := &cobra.Command{
+		Use:   use,
 		Short: "List deck names",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -426,6 +470,29 @@ func newDecksCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVar(&decksRoot, "decks-root", "", "root directory for decks")
 	return cmd
+}
+
+// RunDeckCreate creates a new deck directory under decksRoot. The deck name is
+// normalized into a filesystem-safe identifier via slug.Slugify. It returns a
+// UsageError if name has no usable characters, and a runtime error if the deck
+// directory already exists. On success it prints the created deck name.
+func RunDeckCreate(decksRoot, name string, stdout io.Writer) error {
+	deckName := slug.Slugify(name)
+	if deckName == "" {
+		return &UsageError{msg: fmt.Sprintf("deck create: %q has no usable characters for a deck name", name)}
+	}
+
+	deckDir := filepath.Join(decksRoot, deckName)
+	if _, err := os.Stat(deckDir); err == nil {
+		return fmt.Errorf("deck create: %s already exists", deckDir)
+	}
+
+	if err := os.MkdirAll(deckDir, 0o755); err != nil {
+		return fmt.Errorf("deck create: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(stdout, deckName)
+	return nil
 }
 
 // RunDecks discovers decks under decksRoot and prints their names sorted

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -928,3 +928,161 @@ func TestConfigNegativeNewPerDayReturnsExitCode2(t *testing.T) {
 		t.Errorf("exit code = %d, want 2 for negative new_per_day", code)
 	}
 }
+
+func TestDeckCreateCommandCreatesDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	cli.SetOutput(io.Discard)
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"deck", "create", "french", "--decks-root", tmpDir})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("deck create command failed: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(tmpDir, "french"))
+	if err != nil {
+		t.Fatalf("stat created deck: %v", err)
+	}
+	if !info.IsDir() {
+		t.Error("created deck path is not a directory")
+	}
+}
+
+func TestDeckCreateCommandSlugifiesName(t *testing.T) {
+	tmpDir := t.TempDir()
+	cli.SetOutput(io.Discard)
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"deck", "create", "My Spanish Verbs!", "--decks-root", tmpDir})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("deck create command failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(tmpDir, "my-spanish-verbs")); err != nil {
+		t.Fatalf("expected slugified deck dir 'my-spanish-verbs': %v", err)
+	}
+}
+
+func TestDeckCreateCommandPrintsCreatedName(t *testing.T) {
+	tmpDir := t.TempDir()
+	cli.SetOutput(io.Discard)
+
+	var stdout bytes.Buffer
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"deck", "create", "My Spanish Verbs!", "--decks-root", tmpDir})
+	cmd.SetOut(&stdout)
+	cmd.SetErr(io.Discard)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("deck create command failed: %v", err)
+	}
+
+	if got := strings.TrimRight(stdout.String(), "\n"); got != "my-spanish-verbs" {
+		t.Errorf("output = %q, want %q", got, "my-spanish-verbs")
+	}
+}
+
+func TestDeckCreateCommandErrorsIfDirectoryExists(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, "french"), 0o755); err != nil {
+		t.Fatalf("mkdir french: %v", err)
+	}
+	cli.SetOutput(io.Discard)
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"deck", "create", "french", "--decks-root", tmpDir})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	if err := cmd.Execute(); err == nil {
+		t.Fatal("expected error when deck directory already exists")
+	}
+
+	code := cli.ExecuteWithArgs([]string{"deck", "create", "french", "--decks-root", tmpDir})
+	if code != 1 {
+		t.Errorf("exit code = %d, want 1 for runtime error (deck exists)", code)
+	}
+}
+
+func TestDeckCreateCommandMissingArgReturnsExitCode2(t *testing.T) {
+	cli.SetOutput(io.Discard)
+	code := cli.ExecuteWithArgs([]string{"deck", "create"})
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2 for usage error", code)
+	}
+}
+
+func TestDeckCreateCommandEmptySlugReturnsExitCode2(t *testing.T) {
+	tmpDir := t.TempDir()
+	cli.SetOutput(io.Discard)
+	code := cli.ExecuteWithArgs([]string{"deck", "create", "!!!", "--decks-root", tmpDir})
+	if code != 2 {
+		t.Errorf("exit code = %d, want 2 for unusable deck name", code)
+	}
+}
+
+func TestDeckListCommandSortsAlphabetically(t *testing.T) {
+	tmpDir := t.TempDir()
+	for _, name := range []string{"zoo", "alpha", "med"} {
+		if err := os.MkdirAll(filepath.Join(tmpDir, name), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", name, err)
+		}
+	}
+
+	var stdout bytes.Buffer
+	cli.SetOutput(io.Discard)
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"deck", "list", "--decks-root", tmpDir})
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stdout)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("deck list command failed: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n")
+	want := []string{"alpha", "med", "zoo"}
+	if len(lines) != len(want) {
+		t.Fatalf("lines = %v, want %v", lines, want)
+	}
+	for i, got := range lines {
+		if got != want[i] {
+			t.Errorf("lines[%d] = %q, want %q", i, got, want[i])
+		}
+	}
+}
+
+func TestDeckListMatchesDecksAlias(t *testing.T) {
+	tmpDir := t.TempDir()
+	for _, name := range []string{"french", "golang", "med"} {
+		if err := os.MkdirAll(filepath.Join(tmpDir, name), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", name, err)
+		}
+	}
+	cli.SetOutput(io.Discard)
+
+	run := func(args ...string) string {
+		var stdout bytes.Buffer
+		cmd := cli.NewRootCmd()
+		cmd.SetArgs(args)
+		cmd.SetOut(&stdout)
+		cmd.SetErr(io.Discard)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("%v command failed: %v", args, err)
+		}
+		return stdout.String()
+	}
+
+	deckList := run("deck", "list", "--decks-root", tmpDir)
+	decks := run("decks", "--decks-root", tmpDir)
+	if deckList != decks {
+		t.Errorf("deck list output %q differs from decks alias output %q", deckList, decks)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `deck` parent command to the CLI grouping deck-management subcommands, per #62.

- `srs deck create <name>` — creates a deck directory under the decks root, normalizing the name into a filesystem-safe identifier via `slug.Slugify`. Errors if the deck already exists (exit 1); reports a usage error (exit 2) when the name has no usable characters. Prints the created deck name on success.
- `srs deck list` — lists deck names, sharing `RunDecks` with the existing top-level command.
- `srs decks` — kept as a backward-compatible alias, now built from the same `newDeckListCmd` helper as `deck list`.

## Acceptance criteria

- [x] `srs deck create <name>` creates a deck directory under decks root with slugified name
- [x] `srs deck create <name>` errors if the directory already exists
- [x] `srs deck list` outputs deck names sorted alphabetically, one per line (same as `srs decks`)
- [x] `srs decks` remains as a backward-compatible alias for `srs deck list`
- [x] Integration tests follow existing `cli_test.go` patterns (temp dirs, SetOutput, etc.)

## Testing

- `go test ./...` — all packages pass
- `gofmt -l` clean, `go vet` clean, `golangci-lint run` — 0 issues
- Manual smoke test: created decks with slugification, verified `deck list`/`decks` parity and the duplicate-deck error path

Closes: #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)