### PR TITLE
feat(tui): add N keybinding for deck creation in picker

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -275,7 +275,7 @@ func defaultPickerRun(decksRoot string) error {
 		), nil
 	}
 
-	m := tui.NewPickerModel(entries, onSelect)
+	m := tui.NewPickerModel(entries, onSelect, tui.WithDecksRoot(decksRoot))
 	p := tea.NewProgram(m, tea.WithAltScreen())
 	_, err = p.Run()
 	return err

--- a/internal/tui/picker.go
+++ b/internal/tui/picker.go
@@ -2,10 +2,14 @@ package tui
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/jvcorredor/srs-tui/internal/slug"
 )
 
 // DeckEntry describes a single deck shown in the picker.
@@ -34,13 +38,25 @@ func (d deckItem) FilterValue() string { return d.entry.Name }
 // It returns the new tea.Model and tea.Cmd to replace the picker with.
 type OnSelectFunc func(entry DeckEntry) (tea.Model, tea.Cmd)
 
+// PickerOption configures a PickerModel at construction time.
+type PickerOption func(*PickerModel)
+
+// WithDecksRoot sets the directory under which the picker creates new deck
+// directories when the user presses N. Without it, deck creation is disabled.
+func WithDecksRoot(root string) PickerOption {
+	return func(m *PickerModel) { m.decksRoot = root }
+}
+
 // PickerModel is a Bubble Tea model that shows a list of decks with their
 // due-card counts and lets the user pick one to review.
 type PickerModel struct {
-	list     list.Model
-	onSelect OnSelectFunc
-	empty    bool
-	items    []DeckEntry
+	list      list.Model
+	onSelect  OnSelectFunc
+	empty     bool
+	items     []DeckEntry
+	decksRoot string
+	creating  bool
+	nameInput textinput.Model
 }
 
 // SelectedIndex returns the index of the currently highlighted deck.
@@ -53,7 +69,7 @@ func (m PickerModel) SelectedIndex() int {
 
 // NewPickerModel creates a PickerModel. If decks is empty or nil, the picker
 // shows an empty-state message. onSelect is called when the user selects a deck.
-func NewPickerModel(decks []DeckEntry, onSelect OnSelectFunc) PickerModel {
+func NewPickerModel(decks []DeckEntry, onSelect OnSelectFunc, opts ...PickerOption) PickerModel {
 	var items []list.Item
 	for _, d := range decks {
 		items = append(items, deckItem{entry: d})
@@ -67,15 +83,25 @@ func NewPickerModel(decks []DeckEntry, onSelect OnSelectFunc) PickerModel {
 		return []key.Binding{
 			key.NewBinding(key.WithKeys("j"), key.WithHelp("j", "down")),
 			key.NewBinding(key.WithKeys("k"), key.WithHelp("k", "up")),
+			key.NewBinding(key.WithKeys("N"), key.WithHelp("N", "new deck")),
 		}
 	}
 
-	return PickerModel{
-		list:     l,
-		onSelect: onSelect,
-		empty:    len(decks) == 0,
-		items:    decks,
+	ti := textinput.New()
+	ti.Prompt = "New deck: "
+	ti.Placeholder = "deck name"
+
+	m := PickerModel{
+		list:      l,
+		onSelect:  onSelect,
+		empty:     len(decks) == 0,
+		items:     decks,
+		nameInput: ti,
 	}
+	for _, opt := range opts {
+		opt(&m)
+	}
+	return m
 }
 
 // Init implements tea.Model.
@@ -85,18 +111,30 @@ func (m PickerModel) Init() tea.Cmd {
 
 // Update implements tea.Model.
 func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.creating {
+		return m.updateCreating(msg)
+	}
+
+	keyMsg, isKey := msg.(tea.KeyMsg)
+
 	if m.empty {
-		if key, ok := msg.(tea.KeyMsg); ok && key.String() == "q" {
-			return m, tea.Quit
+		if isKey {
+			switch keyMsg.String() {
+			case "q":
+				return m, tea.Quit
+			case "N":
+				return m.startCreating()
+			}
 		}
 		return m, nil
 	}
 
-	switch msg := msg.(type) {
-	case tea.KeyMsg:
-		switch msg.String() {
+	if isKey {
+		switch keyMsg.String() {
 		case "q":
 			return m, tea.Quit
+		case "N":
+			return m.startCreating()
 		case "j":
 			m.list.CursorDown()
 			return m, nil
@@ -120,10 +158,78 @@ func (m PickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+// startCreating opens the inline deck-name textinput overlay.
+func (m PickerModel) startCreating() (tea.Model, tea.Cmd) {
+	m.creating = true
+	m.nameInput.SetValue("")
+	cmd := m.nameInput.Focus()
+	return m, cmd
+}
+
+// updateCreating handles input while the deck-name textinput overlay is active.
+func (m PickerModel) updateCreating(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if keyMsg, ok := msg.(tea.KeyMsg); ok {
+		switch keyMsg.String() {
+		case "esc":
+			m.creating = false
+			m.nameInput.Blur()
+			m.nameInput.SetValue("")
+			return m, nil
+		case "enter":
+			name := slug.Slugify(m.nameInput.Value())
+			if name == "" {
+				// Nothing slug-worthy was typed; keep the overlay open.
+				return m, nil
+			}
+			m.creating = false
+			m.nameInput.Blur()
+			m.nameInput.SetValue("")
+			return m.createDeck(name)
+		}
+	}
+
+	var cmd tea.Cmd
+	m.nameInput, cmd = m.nameInput.Update(msg)
+	return m, cmd
+}
+
+// createDeck creates the deck directory for the slugified name and adds it to
+// the picker list with the cursor on it. If a deck with that name already
+// exists, the cursor simply jumps to it.
+func (m PickerModel) createDeck(name string) (tea.Model, tea.Cmd) {
+	path := filepath.Join(m.decksRoot, name)
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		// Surfacing errors would require a status line the picker does not
+		// yet have; for now leave the list unchanged on failure.
+		return m, nil
+	}
+
+	for i, e := range m.items {
+		if e.Name == name {
+			m.list.Select(i)
+			return m, nil
+		}
+	}
+
+	entry := DeckEntry{Name: name, Path: path}
+	m.items = append(m.items, entry)
+	idx := len(m.items) - 1
+	cmd := m.list.InsertItem(idx, deckItem{entry: entry})
+	m.list.Select(idx)
+	m.empty = false
+	return m, cmd
+}
+
 // View implements tea.Model.
 func (m PickerModel) View() string {
+	if m.creating {
+		if m.empty {
+			return m.nameInput.View() + "\nPress Esc to cancel."
+		}
+		return m.list.View() + "\n" + m.nameInput.View()
+	}
 	if m.empty {
-		return "No decks found.\nRun srs init to get started, then srs new to create cards.\nPress q to quit."
+		return "No decks found. Press `N` to create one, or run `srs init` to get started. Press `q` to quit."
 	}
 	return m.list.View()
 }

--- a/internal/tui/picker_test.go
+++ b/internal/tui/picker_test.go
@@ -1,6 +1,8 @@
 package tui_test
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -39,16 +41,16 @@ func asPicker(m tea.Model) tui.PickerModel {
 }
 
 // TestPickerEmptyStateShowsFriendlyMessage verifies that the picker displays
-// a helpful message when there are no decks, pointing the user at srs init
-// and srs new.
+// a helpful message when there are no decks, pointing the user at the N
+// keybinding and srs init.
 func TestPickerEmptyStateShowsFriendlyMessage(t *testing.T) {
 	m := tui.NewPickerModel(nil, nil)
 	view := m.View()
 	if !strings.Contains(view, "srs init") {
 		t.Errorf("empty picker should mention 'srs init', got:\n%s", view)
 	}
-	if !strings.Contains(view, "srs new") {
-		t.Errorf("empty picker should mention 'srs new', got:\n%s", view)
+	if !strings.Contains(view, "`N`") {
+		t.Errorf("empty picker should mention the N keybinding, got:\n%s", view)
 	}
 }
 
@@ -167,5 +169,105 @@ func TestPickerSelectTransitionsToReviewModel(t *testing.T) {
 	}
 	if _, ok := modelReturned.(tui.ReviewModel); !ok {
 		t.Errorf("expected tui.ReviewModel, got %T", modelReturned)
+	}
+}
+
+// typePicker feeds each rune of s to the model as a key message, mimicking a
+// user typing into the deck-name textinput.
+func typePicker(m tui.PickerModel, s string) tui.PickerModel {
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)})
+	return asPicker(updated)
+}
+
+// pressN sends a Shift+N key message to the model.
+func pressN(m tui.PickerModel) tui.PickerModel {
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'N'}})
+	return asPicker(updated)
+}
+
+// TestPickerNActivatesTextinput verifies that pressing N opens the inline
+// deck-name textinput overlay.
+func TestPickerNActivatesTextinput(t *testing.T) {
+	decks := []tui.DeckEntry{{Name: "french", Path: "/tmp/french"}}
+	m := tui.NewPickerModel(decks, nil, tui.WithDecksRoot(t.TempDir()))
+	m = pressN(m)
+	if !strings.Contains(m.View(), "New deck") {
+		t.Errorf("after N, view should show the deck-name input, got:\n%s", m.View())
+	}
+}
+
+// TestPickerCreateDeckAddsToListAndJumpsCursor verifies that submitting a
+// deck name creates the directory, adds the deck to the list, and moves the
+// cursor onto the new deck.
+func TestPickerCreateDeckAddsToListAndJumpsCursor(t *testing.T) {
+	root := t.TempDir()
+	decks := []tui.DeckEntry{
+		{Name: "french", Path: filepath.Join(root, "french")},
+		{Name: "golang", Path: filepath.Join(root, "golang")},
+	}
+	m := tui.NewPickerModel(decks, nil, tui.WithDecksRoot(root))
+	m = pressN(m)
+	m = typePicker(m, "Spanish Vocab")
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = asPicker(updated)
+
+	deckDir := filepath.Join(root, "spanish-vocab")
+	if info, err := os.Stat(deckDir); err != nil || !info.IsDir() {
+		t.Fatalf("deck directory %s should exist, err=%v", deckDir, err)
+	}
+	view := m.View()
+	if !strings.Contains(view, "spanish-vocab") {
+		t.Errorf("new deck should appear in picker list, got:\n%s", view)
+	}
+	if m.SelectedIndex() != 2 {
+		t.Errorf("cursor should be on the new deck (index 2), got %d", m.SelectedIndex())
+	}
+}
+
+// TestPickerCreateFirstDeckFromEmpty verifies that N works on the empty
+// picker and creates the very first deck.
+func TestPickerCreateFirstDeckFromEmpty(t *testing.T) {
+	root := t.TempDir()
+	m := tui.NewPickerModel(nil, nil, tui.WithDecksRoot(root))
+	m = pressN(m)
+	m = typePicker(m, "my first deck")
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = asPicker(updated)
+
+	if info, err := os.Stat(filepath.Join(root, "my-first-deck")); err != nil || !info.IsDir() {
+		t.Fatalf("first deck directory should exist, err=%v", err)
+	}
+	if !strings.Contains(m.View(), "my-first-deck") {
+		t.Errorf("first deck should appear in picker list, got:\n%s", m.View())
+	}
+}
+
+// TestPickerEscDismissesTextinput verifies that Esc cancels the deck-name
+// overlay and returns to the normal picker without creating anything.
+func TestPickerEscDismissesTextinput(t *testing.T) {
+	root := t.TempDir()
+	decks := []tui.DeckEntry{{Name: "french", Path: filepath.Join(root, "french")}}
+	m := tui.NewPickerModel(decks, nil, tui.WithDecksRoot(root))
+	m = pressN(m)
+	m = typePicker(m, "discarded")
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = asPicker(updated)
+
+	if strings.Contains(m.View(), "New deck") {
+		t.Errorf("Esc should dismiss the deck-name input, got:\n%s", m.View())
+	}
+	if _, err := os.Stat(filepath.Join(root, "discarded")); !os.IsNotExist(err) {
+		t.Errorf("Esc should not create a deck directory")
+	}
+}
+
+// TestPickerLowercaseNDoesNothingOnEmpty verifies that the lowercase n key
+// does nothing on the empty picker.
+func TestPickerLowercaseNDoesNothingOnEmpty(t *testing.T) {
+	m := tui.NewPickerModel(nil, nil, tui.WithDecksRoot(t.TempDir()))
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}})
+	m = asPicker(updated)
+	if strings.Contains(m.View(), "New deck") {
+		t.Errorf("lowercase n should not open the deck-name input, got:\n%s", m.View())
 	}
 }


### PR DESCRIPTION
## Summary

Adds a `N` (shift+n) keybinding to the deck picker that opens an inline `bubbles/textinput` overlay for naming a new deck. On submit, the deck name is slugified via `internal/slug`, the deck directory is created with `os.MkdirAll`, the deck is inserted into the picker list, and the cursor jumps onto it. `Esc` dismisses the overlay without creating anything.

Deck creation also works from the empty picker, so the first deck can be created without leaving the TUI. The empty-state message is updated to point users at `N` and `srs init`. Lowercase `n` does nothing.

## Changes

- `internal/tui/picker.go`: new `creating` state + `textinput` overlay, `createDeck` helper, `WithDecksRoot` functional option, updated empty-state message and short-help.
- `internal/cli/cli.go`: pass `WithDecksRoot(decksRoot)` when building the picker.
- `internal/tui/picker_test.go`: tests for the textinput overlay, deck creation (incl. from empty picker), slugification, `Esc` cancel, and lowercase `n`.

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` — all pass.

Closes: #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)