### PR TITLE
feat(cli): harden `srs new` to require an existing deck

### DIFF
--- a/docs/adr/0001-auto-slugify-names.md
+++ b/docs/adr/0001-auto-slugify-names.md
@@ -1,0 +1,49 @@
+# 1. Auto-slugify card and deck names
+
+Date: 2026-05-17
+
+## Status
+
+Accepted
+
+## Context
+
+Decks are directories and cards are `.md` files on disk. Users supply deck and
+card names as free text on the command line and in the TUI (`srs new`,
+`srs deck create`, the `N` keybinding). Free text contains spaces, punctuation,
+mixed case, and unicode — none of which makes a good filesystem identifier.
+Without normalisation we would either reject perfectly reasonable names or
+create files and directories whose names are awkward to type, inconsistent
+across platforms, and ambiguous to match later.
+
+We also need a single, predictable rule so that the same human-readable name
+always resolves to the same on-disk identifier, regardless of which entry point
+created it.
+
+## Decision
+
+Every human-supplied card and deck name is passed through a shared
+`internal/slug.Slugify` helper before it touches the filesystem. Slugify:
+
+- lowercases the input,
+- replaces every run of non-`[a-z0-9]` runes with a single hyphen,
+- strips leading and trailing hyphens.
+
+The slug is the canonical on-disk identifier. `My Spanish Verbs!` becomes
+`my-spanish-verbs`; `To Be (ser)` becomes `to-be-ser`. Input with no
+alphanumeric characters slugifies to the empty string and is rejected as a
+usage error.
+
+`Slugify` lives in its own package so the CLI and the TUI share exactly one
+implementation and cannot drift.
+
+## Consequences
+
+- Card and deck names on disk are consistent, portable, and easy to type.
+- A name and its slug are not the same string; commands that look up an
+  existing deck must slugify the argument before matching.
+- Two distinct display names can collapse to the same slug (`C#` and `C++`
+  both slugify to `c`); the second attempt to create that identifier fails as
+  "already exists", which is acceptable for a single-user local tool.
+- All-punctuation names are rejected rather than silently turned into empty
+  filenames.

--- a/docs/adr/0002-srs-new-requires-existing-deck.md
+++ b/docs/adr/0002-srs-new-requires-existing-deck.md
@@ -1,0 +1,54 @@
+# 2. `srs new` requires an existing deck
+
+Date: 2026-05-17
+
+## Status
+
+Accepted
+
+## Context
+
+`srs new <deck> <name>` creates a card inside a deck. Originally the command
+called `os.MkdirAll` on the deck path, so an unrecognised `<deck>` argument was
+treated as a brand-new deck and created on the spot.
+
+This is a silent-failure hazard. A typo — `srs new spnaish hola` instead of
+`spanish` — does not fail. It creates a stray `spnaish` deck, writes the card
+into it, and opens the editor. The user only discovers the mistake later, when
+the expected deck is missing a card and an unwanted deck has appeared. There is
+no signal at the moment the mistake is made.
+
+Deck creation is already a deliberate, explicit action available through
+`srs deck create` and the TUI `N` keybinding. `srs new` having a second,
+implicit path to deck creation gives the command two jobs and makes the
+dangerous outcome indistinguishable from the intended one.
+
+## Decision
+
+`srs new` only ever adds cards to decks that **already exist**.
+
+- The `<deck>` argument is slugified (see ADR 0001) and matched against the
+  existing deck directories under the decks root.
+- If the deck exists, the card is created as before.
+- If the deck does not exist, `srs new` does **not** create it. It returns a
+  plain runtime error (exit code 1 — not a usage error, because the arguments
+  are well-formed). The message is actionable:
+  - if an existing deck is within a small edit distance of the argument, it
+    appends `Did you mean "<deck>"?`;
+  - otherwise it lists the decks that do exist;
+  - if there are no decks at all, it tells the user to run `srs deck create`.
+- The edit-distance match uses a hand-rolled Levenshtein helper — no new
+  third-party dependency.
+- There is no `--create-deck` flag. `srs new` has exactly one job and never
+  turns a free-text argument into a directory.
+
+## Consequences
+
+- A mistyped deck name fails loudly and immediately, with a suggestion, instead
+  of silently creating a stray deck.
+- This is a **behaviour change**. Anyone scripting `srs new` against a
+  not-yet-created deck must now run `srs deck create` first; the previous
+  implicit-creation behaviour is gone.
+- Deck creation lives in exactly one place per surface (`srs deck create`, the
+  TUI `N` keybinding), making the codebase easier to reason about.
+- `srs new` still refuses to overwrite an existing card file.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -322,13 +323,18 @@ func newReviewCmd() *cobra.Command {
 }
 
 // newNewCmd creates the "new <deck> <name>" command for adding cards.
+//
+// The command only ever adds cards to decks that already exist: it slugifies
+// both arguments and matches the deck against existing deck directories.
+// Deck creation lives solely in "srs deck create"; an unknown deck argument
+// never silently creates a directory.
 func newNewCmd() *cobra.Command {
 	var cloze bool
 	var decksRoot string
 
 	cmd := &cobra.Command{
 		Use:   "new <deck> <name>",
-		Short: "Create a new card and open it in your editor",
+		Short: "Create a new card in an existing deck and open it in your editor",
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 2 {
 				return &UsageError{msg: fmt.Sprintf("accepts 2 arg(s), received %d", len(args))}
@@ -336,19 +342,24 @@ func newNewCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			deckName := args[0]
-			cardName := args[1]
-
-			root := paths.DecksRoot(decksRoot)
-			deckDir := filepath.Join(root, deckName)
-			cardPath := filepath.Join(deckDir, cardName+".md")
-
-			if _, err := os.Stat(cardPath); err == nil {
-				return fmt.Errorf("new: %s already exists", cardPath)
+			deckSlug := slug.Slugify(args[0])
+			if deckSlug == "" {
+				return &UsageError{msg: fmt.Sprintf("new: %q has no usable characters for a deck name", args[0])}
+			}
+			cardSlug := slug.Slugify(args[1])
+			if cardSlug == "" {
+				return &UsageError{msg: fmt.Sprintf("new: %q has no usable characters for a card name", args[1])}
 			}
 
-			if err := os.MkdirAll(deckDir, 0o755); err != nil {
-				return fmt.Errorf("new: create deck dir: %w", err)
+			root := paths.DecksRoot(decksRoot)
+			deckDir, err := resolveExistingDeck(root, deckSlug)
+			if err != nil {
+				return err
+			}
+
+			cardPath := filepath.Join(deckDir, cardSlug+".md")
+			if _, err := os.Stat(cardPath); err == nil {
+				return fmt.Errorf("new: %s already exists", cardPath)
 			}
 
 			cardType := card.Basic
@@ -363,12 +374,101 @@ func newNewCmd() *cobra.Command {
 
 			return editorRun(cardPath)
 		},
+		SilenceUsage: true,
 	}
 
 	cmd.Flags().BoolVar(&cloze, "cloze", false, "create a cloze-deletion card")
 	cmd.Flags().StringVar(&decksRoot, "decks-root", "", "root directory for decks")
 
 	return cmd
+}
+
+// resolveExistingDeck returns the directory of the deck identified by deckSlug
+// under decksRoot. "srs new" never creates decks: when the deck directory does
+// not exist it returns a plain runtime error (exit code 1) whose message helps
+// the user recover — suggesting the closest existing deck, listing the decks
+// that do exist, or pointing at "srs deck create" when there are none.
+func resolveExistingDeck(decksRoot, deckSlug string) (string, error) {
+	deckDir := filepath.Join(decksRoot, deckSlug)
+	if info, err := os.Stat(deckDir); err == nil && info.IsDir() {
+		return deckDir, nil
+	}
+
+	names := existingDeckNames(decksRoot)
+	if len(names) == 0 {
+		return "", fmt.Errorf("new: deck %q does not exist; create it first with: srs deck create %s", deckSlug, deckSlug)
+	}
+	if suggestion, ok := closestDeck(deckSlug, names); ok {
+		return "", fmt.Errorf("new: deck %q does not exist. Did you mean %q?", deckSlug, suggestion)
+	}
+	return "", fmt.Errorf("new: deck %q does not exist. Existing decks: %s", deckSlug, strings.Join(names, ", "))
+}
+
+// existingDeckNames returns the directory names of every deck under decksRoot,
+// sorted alphabetically. A missing or unreadable root yields nil.
+func existingDeckNames(decksRoot string) []string {
+	deckPaths, err := deck.Discover(decksRoot)
+	if err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(deckPaths))
+	for _, p := range deckPaths {
+		names = append(names, filepath.Base(p))
+	}
+	sort.Strings(names)
+	return names
+}
+
+// closestDeck returns the deck name from names with the smallest Levenshtein
+// distance to target, together with true, when that distance is within a small
+// edit-distance threshold. Otherwise it returns "", false and the caller falls
+// back to listing every existing deck.
+func closestDeck(target string, names []string) (string, bool) {
+	best := ""
+	bestDist := -1
+	for _, n := range names {
+		d := levenshtein(target, n)
+		if bestDist < 0 || d < bestDist {
+			best, bestDist = n, d
+		}
+	}
+	if best == "" {
+		return "", false
+	}
+	// Roughly one edit per three characters, but always at least two so short
+	// typos and transpositions ("spnaish" -> "spanish") still match.
+	threshold := len(target) / 3
+	if threshold < 2 {
+		threshold = 2
+	}
+	if bestDist <= threshold {
+		return best, true
+	}
+	return "", false
+}
+
+// levenshtein computes the Levenshtein edit distance between a and b using a
+// rolling two-row dynamic-programming table. It is a hand-rolled helper so the
+// did-you-mean suggestion needs no third-party dependency.
+func levenshtein(a, b string) int {
+	ra, rb := []rune(a), []rune(b)
+	prev := make([]int, len(rb)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(ra); i++ {
+		curr := make([]int, len(rb)+1)
+		curr[0] = i
+		for j := 1; j <= len(rb); j++ {
+			cost := 1
+			if ra[i-1] == rb[j-1] {
+				cost = 0
+			}
+			curr[j] = min(prev[j]+1, curr[j-1]+1, prev[j-1]+cost)
+		}
+		prev = curr
+	}
+	return prev[len(rb)]
 }
 
 // newVersionCmd creates the "version" command.

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -24,6 +24,16 @@ import (
 // noBuildInfo returns nil to simulate a binary built without debug info.
 func noBuildInfo() (*debug.BuildInfo, bool) { return nil, false }
 
+// mkDeck creates an empty deck directory named name under root. "srs new" now
+// requires the deck to already exist, so card-creation tests stage their decks
+// up front with this helper.
+func mkDeck(t *testing.T, root, name string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, name), 0o755); err != nil {
+		t.Fatalf("mkdir deck %s: %v", name, err)
+	}
+}
+
 // TestVersionCommandPrintsVersion checks that the version subcommand prints the
 // version string, commit hash, and build date in text format.
 func TestVersionCommandPrintsVersion(t *testing.T) {
@@ -308,6 +318,7 @@ func TestMakeRateFuncUpdatesOnlyActiveClozeGroup(t *testing.T) {
 // command creates a Markdown card file with the correct frontmatter fields.
 func TestNewCommandCreatesCardFileWithPrefilledFrontmatter(t *testing.T) {
 	tmpDir := t.TempDir()
+	mkDeck(t, tmpDir, "french")
 	cli.SetOutput(io.Discard)
 	cli.SetEditorRun(func(_ string) error { return nil })
 
@@ -345,6 +356,7 @@ func TestNewCommandCreatesCardFileWithPrefilledFrontmatter(t *testing.T) {
 // produces a card with type "cloze" and a cloze-deletion syntax hint.
 func TestNewCommandWithClozeFlagCreatesClozeCard(t *testing.T) {
 	tmpDir := t.TempDir()
+	mkDeck(t, tmpDir, "med")
 	cli.SetOutput(io.Discard)
 	cli.SetEditorRun(func(_ string) error { return nil })
 
@@ -378,6 +390,7 @@ func TestNewCommandWithClozeFlagCreatesClozeCard(t *testing.T) {
 // target card file already exists.
 func TestNewCommandRefusesOverwrite(t *testing.T) {
 	tmpDir := t.TempDir()
+	mkDeck(t, tmpDir, "french")
 	cli.SetOutput(io.Discard)
 	cli.SetEditorRun(func(_ string) error { return nil })
 
@@ -404,6 +417,7 @@ func TestNewCommandRefusesOverwrite(t *testing.T) {
 // runner with the path of the newly created card file.
 func TestNewCommandLaunchesEditor(t *testing.T) {
 	tmpDir := t.TempDir()
+	mkDeck(t, tmpDir, "french")
 	var editorCalledWith string
 	cli.SetOutput(io.Discard)
 	cli.SetEditorRun(func(file string) error {
@@ -425,33 +439,107 @@ func TestNewCommandLaunchesEditor(t *testing.T) {
 	}
 }
 
-// TestNewCommandCreatesDeckDirectoryIfMissing verifies that the new command
-// creates the deck directory when it does not already exist.
-func TestNewCommandCreatesDeckDirectoryIfMissing(t *testing.T) {
+// TestNewCommandSlugifiesDeckAndCardNames verifies that the new command
+// slugifies both the deck argument (to match an existing deck directory) and
+// the card argument (into the card filename).
+func TestNewCommandSlugifiesDeckAndCardNames(t *testing.T) {
 	tmpDir := t.TempDir()
+	mkDeck(t, tmpDir, "spanish-verbs")
 	cli.SetOutput(io.Discard)
 	cli.SetEditorRun(func(_ string) error { return nil })
 
 	cmd := cli.NewRootCmd()
-	cmd.SetArgs([]string{"new", "brand-new-deck", "card1", "--decks-root", tmpDir})
+	cmd.SetArgs([]string{"new", "Spanish Verbs", "To Be (ser)", "--decks-root", tmpDir})
 	cmd.SetOut(io.Discard)
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("new command failed: %v", err)
 	}
 
-	deckDir := filepath.Join(tmpDir, "brand-new-deck")
-	info, err := os.Stat(deckDir)
-	if err != nil {
-		t.Fatalf("deck directory not created: %v", err)
+	cardPath := filepath.Join(tmpDir, "spanish-verbs", "to-be-ser.md")
+	if _, err := os.Stat(cardPath); err != nil {
+		t.Fatalf("expected slugified card at %s: %v", cardPath, err)
 	}
-	if !info.IsDir() {
-		t.Error("deck path is not a directory")
+}
+
+// TestNewCommandUnknownDeckSuggestsClosest verifies that a mistyped deck
+// argument does not create a directory and instead returns a plain runtime
+// error (exit code 1) suggesting the closest existing deck.
+func TestNewCommandUnknownDeckSuggestsClosest(t *testing.T) {
+	tmpDir := t.TempDir()
+	mkDeck(t, tmpDir, "spanish")
+	cli.SetOutput(io.Discard)
+	cli.SetEditorRun(func(_ string) error { return nil })
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"new", "spnaish", "hola", "--decks-root", tmpDir})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for unknown deck")
+	}
+	if !strings.Contains(err.Error(), `Did you mean "spanish"?`) {
+		t.Errorf("error should suggest closest deck, got: %v", err)
 	}
 
-	cardPath := filepath.Join(deckDir, "card1.md")
-	if _, err := os.Stat(cardPath); err != nil {
-		t.Fatalf("card file not created: %v", err)
+	if _, statErr := os.Stat(filepath.Join(tmpDir, "spnaish")); !os.IsNotExist(statErr) {
+		t.Error("unknown deck must not be created on disk")
+	}
+
+	code := cli.ExecuteWithArgs([]string{"new", "spnaish", "hola", "--decks-root", tmpDir})
+	if code != 1 {
+		t.Errorf("exit code = %d, want 1 for unknown-deck runtime error", code)
+	}
+}
+
+// TestNewCommandUnknownDeckListsExistingDecks verifies that an unknown deck
+// argument with no close match lists the decks that do exist.
+func TestNewCommandUnknownDeckListsExistingDecks(t *testing.T) {
+	tmpDir := t.TempDir()
+	mkDeck(t, tmpDir, "french")
+	mkDeck(t, tmpDir, "german")
+	cli.SetOutput(io.Discard)
+	cli.SetEditorRun(func(_ string) error { return nil })
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"new", "xylophone", "note", "--decks-root", tmpDir})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error for unknown deck")
+	}
+	msg := err.Error()
+	if strings.Contains(msg, "Did you mean") {
+		t.Errorf("a distant deck name should not produce a did-you-mean suggestion: %v", err)
+	}
+	if !strings.Contains(msg, "french") || !strings.Contains(msg, "german") {
+		t.Errorf("error should list existing decks, got: %v", err)
+	}
+}
+
+// TestNewCommandUnknownDeckWithNoDecksSuggestsDeckCreate verifies that, when no
+// decks exist at all, the unknown-deck error points the user at the
+// "srs deck create" command.
+func TestNewCommandUnknownDeckWithNoDecksSuggestsDeckCreate(t *testing.T) {
+	tmpDir := t.TempDir()
+	cli.SetOutput(io.Discard)
+	cli.SetEditorRun(func(_ string) error { return nil })
+
+	cmd := cli.NewRootCmd()
+	cmd.SetArgs([]string{"new", "spanish", "hola", "--decks-root", tmpDir})
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error when no decks exist")
+	}
+	if !strings.Contains(err.Error(), "srs deck create") {
+		t.Errorf("error should point to 'srs deck create', got: %v", err)
 	}
 }
 
@@ -459,6 +547,7 @@ func TestNewCommandCreatesDeckDirectoryIfMissing(t *testing.T) {
 // leave temporary files in the deck directory after creating a card.
 func TestNewCommandAtomicWriteNoTmpArtifacts(t *testing.T) {
 	tmpDir := t.TempDir()
+	mkDeck(t, tmpDir, "french")
 	cli.SetOutput(io.Discard)
 	cli.SetEditorRun(func(_ string) error { return nil })
 
@@ -496,6 +585,7 @@ func TestNewCommandUsageErrorReturnsExitCode2(t *testing.T) {
 // exit code 1 when the new command encounters a runtime error (file exists).
 func TestNewCommandRuntimeErrorReturnsExitCode1(t *testing.T) {
 	tmpDir := t.TempDir()
+	mkDeck(t, tmpDir, "french")
 	cli.SetOutput(io.Discard)
 	cli.SetEditorRun(func(_ string) error { return nil })
 


### PR DESCRIPTION
## Summary

`srs new <deck> <name>` previously called `os.MkdirAll` on the deck path, so a typo (`spnaish` for `spanish`) silently created a stray deck and wrote the card into it. After this change `srs new` only ever adds cards to decks that **already exist** — deck creation lives solely in `srs deck create` and the TUI `N` keybinding.

## Changes

- `<deck>` and `<name>` are both slugified (via `internal/slug`); the deck slug is matched against existing deck directories under the decks root.
- `os.MkdirAll` deck creation removed from `srs new`; an unknown deck never creates a directory.
- Unknown deck returns a **plain runtime error (exit 1)**, not a `UsageError` — the arguments are well-formed. The message is actionable:
  - `Did you mean "<deck>"?` when an existing deck is within a small edit distance;
  - lists existing deck names when there is no close match;
  - points to `srs deck create` when there are no decks at all.
- Edit-distance matching uses a hand-rolled Levenshtein helper — no new third-party dependency.
- `srs new` still errors if the slugified card file already exists.
- Adds `docs/adr/0001-auto-slugify-names.md` and `docs/adr/0002-srs-new-requires-existing-deck.md`.

## Behaviour change

Anyone scripting `srs new` against a not-yet-created deck must now run `srs deck create` first. This is documented in ADR 0002.

## Testing

- Updated existing `new` tests to stage their decks up front (new shared `mkDeck` helper).
- New integration tests: slugified deck/card paths, unknown-deck with did-you-mean, unknown-deck with deck list, unknown-deck with no decks.
- `go build ./...`, `go vet`, and `go test ./...` all pass; manually smoke-tested all three error paths and the happy path.

Closes: #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)